### PR TITLE
Display late votes differently

### DIFF
--- a/PointerStar/Client/Pages/Room.razor
+++ b/PointerStar/Client/Pages/Room.razor
@@ -71,7 +71,12 @@
                                 @user.Name
                                 @if (ViewModel.VotesShown && !string.IsNullOrWhiteSpace(user.Vote))
                                 {
-                                    <span> - @user.Vote</span>
+                                    <span> - </span>
+                                    if (!string.IsNullOrWhiteSpace(user.OriginalVote) && user.OriginalVote != user.Vote)
+                                    {
+                                        <span class="original-vote-value">(@user.OriginalVote) </span>
+                                    }
+                                    <span class="vote-value">@user.Vote</span>
                                 }
                                 else if (ViewModel.IsFacilitator && ViewModel.PreviewVotes)
                                 {

--- a/PointerStar/Client/Pages/Room.razor.css
+++ b/PointerStar/Client/Pages/Room.razor.css
@@ -33,3 +33,11 @@
 .vote-preview {
     font-style:italic
 }
+
+.original-vote-value {
+    font-style:italic
+}
+
+.vote-value {
+    font-weight:bold
+}

--- a/PointerStar/Server/Room/InMemoryRoomManager.cs
+++ b/PointerStar/Server/Room/InMemoryRoomManager.cs
@@ -63,7 +63,11 @@ public class InMemoryRoomManager : IRoomManager
         {
             return room with
             {
-                Users = room.Users.Select(u => u.Id == userId ? u with { Vote = vote } : u).ToArray()
+                Users = room.Users.Select(u => u.Id == userId ? u with
+                {
+                    OriginalVote = room.VotesShown ? u.OriginalVote : vote,
+                    Vote = vote
+                } : u).ToArray()
             };
         });
     }

--- a/PointerStar/Shared/RoomState.cs
+++ b/PointerStar/Shared/RoomState.cs
@@ -23,6 +23,7 @@ public record class RoomState(string RoomId, User[] Users)
 
 public record class User(Guid Id, string Name)
 {
+    public string? OriginalVote { get; init; }
     public string? Vote { get; init; }
     public Role Role { get; init; } = Role.TeamMember;
 }

--- a/Tests/PointerStar.Server.Tests/Room/RoomManagerTests.cs
+++ b/Tests/PointerStar.Server.Tests/Room/RoomManagerTests.cs
@@ -105,13 +105,38 @@ public abstract class RoomManagerTests<TRoomManager>
         IRoomManager sut = mocker.CreateInstance<TRoomManager>();
 
         _ = await sut.AddUserToRoomAsync(roomId, user, connectionId);
+        
         RoomState? roomState = await sut.SubmitVoteAsync("1", connectionId);
 
         Assert.NotNull(roomState);
         Assert.Single(roomState.Users);
         Assert.Equal("1", roomState.Users.Single().Vote);
+        Assert.Equal("1", roomState.Users.Single().OriginalVote);
     }
 
+    [Fact]
+    public async Task SubmitVoteAsync_AfterVotesShown_UpdatesVote()
+    {
+        AutoMocker mocker = new();
+
+        string roomId = Guid.NewGuid().ToString();
+        string connectionId = Guid.NewGuid().ToString();
+        User user = new(Guid.NewGuid(), "User 1");
+        IRoomManager sut = mocker.CreateInstance<TRoomManager>();
+
+        _ = await sut.AddUserToRoomAsync(roomId, user, connectionId);
+
+        _ = await sut.SubmitVoteAsync("1", connectionId);
+        _ = await sut.ShowVotesAsync(true, connectionId);
+        RoomState? roomState = await sut.SubmitVoteAsync("2", connectionId);
+
+
+        Assert.NotNull(roomState);
+        Assert.Single(roomState.Users);
+        Assert.Equal("2", roomState.Users.Single().Vote);
+        Assert.Equal("1", roomState.Users.Single().OriginalVote);
+    }
+    
     [Fact]
     public async Task SubmitVoteAsync_WithDisconnectedUser_ReturnsNull()
     {


### PR DESCRIPTION
After votes are shown, the user is no longer allowed to change their original vote, only their current vote. 
Original and current votes are displayed differently.

Fixes #10