### PR TITLE
Allowing for automatically showing votes once everyone has submitted

### DIFF
--- a/PointerStar/Client/Pages/Room.razor
+++ b/PointerStar/Client/Pages/Room.razor
@@ -21,6 +21,12 @@
                         <input class="form-check-input" type="checkbox" @bind="ViewModel.VotesShown">
                         <label class="form-check-label" for="flexSwitchCheckDefault">Show votes</label>
                     </div>
+                    <div class="form-check" style="margin: 0px 10px;">
+                        <input class="form-check-input" type="checkbox" value="" id="autoRevealVotesCheckbox" @bind="ViewModel.AutoShowVotes">
+                        <label class="form-check-label" for="autoRevealVotesCheckbox">
+                            Automatically reveal votes
+                        </label>
+                    </div>
                     <div class="form-check form-switch" style="margin-left:10px">
                         <input class="form-check-input" type="checkbox" @bind="ViewModel.PreviewVotes">
                         <label class="form-check-label" for="flexSwitchCheckDefault">Preview votes</label>
@@ -140,7 +146,7 @@
                                 @{
                                     var votes = teamMembers.Select(x => x.Vote).ToArray() ?? Array.Empty<string>();
                                     var groupedVotes = votes.GroupBy(x => x).OrderBy(x => Array.IndexOf(roomState.VoteOptions, x.Key)).ToArray();
-                                    var maxVote = groupedVotes.Select(x => x.Count()).Max();
+                                    int? maxVote = groupedVotes.Any() ? groupedVotes.Select(x => x.Count()).Max() : null;
                                     foreach (var group in groupedVotes)
                                     {
                                         var count = group.Count();

--- a/PointerStar/Client/ViewModels/RoomViewModel.cs
+++ b/PointerStar/Client/ViewModels/RoomViewModel.cs
@@ -38,11 +38,28 @@ public partial class RoomViewModel : ViewModelBase
     [ObservableProperty]
     private bool _previewVotes;
 
+    [ObservableProperty]
+    private bool _autoShowVotes;
+
     async partial void OnVotesShownChanged(bool value)
     {
         if (RoomHubConnection.IsConnected)
         {
-            await RoomHubConnection.ShowVotesAsync(value);
+            await RoomHubConnection.UpdateRoomAsync(new RoomOptions
+            {
+                VotesShown = value
+            });
+        }
+    }
+
+    async partial void OnAutoShowVotesChanged(bool value)
+    {
+        if (RoomHubConnection.IsConnected)
+        {
+            await RoomHubConnection.UpdateRoomAsync(new RoomOptions
+            {
+                AutoShowVotes = value
+            });
         }
     }
 
@@ -57,6 +74,7 @@ public partial class RoomViewModel : ViewModelBase
     {
         RoomState = roomState;
         VotesShown = roomState.VotesShown;
+        AutoShowVotes = roomState.AutoShowVotes;
     }
 
     public async Task SubmitVoteAsync(string vote)

--- a/PointerStar/Server/Hubs/RoomHub.cs
+++ b/PointerStar/Server/Hubs/RoomHub.cs
@@ -46,10 +46,10 @@ public class RoomHub : Hub
         }
     }
 
-    [HubMethodName(RoomHubConnection.ShowVotesMethodName)]
-    public async Task ShowVotesAsync(bool areVotesShown)
+    [HubMethodName(RoomHubConnection.UpdateRoomMethodName)]
+    public async Task UpdateRoomAsync(RoomOptions roomOptions)
     {
-        RoomState? roomState = await RoomManager.ShowVotesAsync(areVotesShown, Context.ConnectionId);
+        RoomState? roomState = await RoomManager.UpdateRoomAsync(roomOptions, Context.ConnectionId);
         if (roomState?.RoomId is { } roomId)
         {
             await Clients.Groups(roomId).SendAsync(RoomHubConnection.RoomUpdatedMethodName, roomState);

--- a/PointerStar/Server/Room/IRoomManager.cs
+++ b/PointerStar/Server/Room/IRoomManager.cs
@@ -6,7 +6,7 @@ public interface IRoomManager
 {
     Task<RoomState> AddUserToRoomAsync(string roomId, User user, string connectionId);
     Task<RoomState?> DisconnectAsync(string connectionId);
-    Task<RoomState?> ShowVotesAsync(bool areVotesShown, string connectionId);
+    Task<RoomState?> UpdateRoomAsync(RoomOptions roomOptions, string connectionId);
     Task<RoomState?> SubmitVoteAsync(string vote, string connectionId);
     Task<RoomState?> ResetVotesAsync(string connectionId);
 }

--- a/PointerStar/Shared/IRoomHubConnection.cs
+++ b/PointerStar/Shared/IRoomHubConnection.cs
@@ -9,6 +9,6 @@ public interface IRoomHubConnection
     Task OpenAsync();
     Task JoinRoomAsync(string roomId, User user);
     Task SubmitVoteAsync(string vote);
-    Task ShowVotesAsync(bool areVotesShown);
+    Task UpdateRoomAsync(RoomOptions roomOptions);
     Task ResetVotesAsync();
 }

--- a/PointerStar/Shared/RoomHubConnection.cs
+++ b/PointerStar/Shared/RoomHubConnection.cs
@@ -7,7 +7,7 @@ public class RoomHubConnection : IRoomHubConnection
 {
     public const string JoinRoomMethodName = "JoinRoom";
     public const string SubmitVoteMethodName = "SubmitVote";
-    public const string ShowVotesMethodName = "ShowVotes";
+    public const string UpdateRoomMethodName = "UpdateRoom";
     public const string ResetVotesMethodName = "ResetVotes";
     public const string RoomUpdatedMethodName = "RoomUpdated";
 
@@ -68,8 +68,8 @@ public class RoomHubConnection : IRoomHubConnection
     public Task SubmitVoteAsync(string vote)
         => HubConnection.InvokeAsync(SubmitVoteMethodName, vote);
 
-    public Task ShowVotesAsync(bool areVotesShown)
-        => HubConnection.InvokeAsync(ShowVotesMethodName, areVotesShown);
+    public Task UpdateRoomAsync(RoomOptions roomOptions)
+        => HubConnection.InvokeAsync(UpdateRoomMethodName, roomOptions);
 
     public Task ResetVotesAsync()
         => HubConnection.InvokeAsync(ResetVotesMethodName);

--- a/PointerStar/Shared/RoomOptions.cs
+++ b/PointerStar/Shared/RoomOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace PointerStar.Shared;
+
+public record class RoomOptions
+{
+    public bool? VotesShown { get; init; }
+    public bool? AutoShowVotes { get; init; }
+}
+

--- a/PointerStar/Shared/RoomState.cs
+++ b/PointerStar/Shared/RoomState.cs
@@ -3,7 +3,8 @@
 public record class RoomState(string RoomId, User[] Users)
 {
     public bool VotesShown { get; init; }
-
+    public bool AutoShowVotes { get; init; }
+    
     public string[] VoteOptions { get; init; } = new[]
     {
         "1",

--- a/Tests/PointerStar.Client.Tests/ViewModels/RoomViewModelTests.cs
+++ b/Tests/PointerStar.Client.Tests/ViewModels/RoomViewModelTests.cs
@@ -111,7 +111,20 @@ public partial class RoomViewModelTests
 
         viewModel.VotesShown = true;
 
-        mocker.Verify<IRoomHubConnection>(x => x.ShowVotesAsync(true), Times.Once);
+        mocker.Verify<IRoomHubConnection>(x => x.UpdateRoomAsync(It.Is<RoomOptions>(o => o.VotesShown == true)), Times.Once);
+    }
+
+    [Fact]
+    public void AutoShowVotes_OnChanged_InvokesHub()
+    {
+        AutoMocker mocker = new();
+        mocker.Setup<IRoomHubConnection, bool>(x => x.IsConnected).Returns(true);
+
+        RoomViewModel viewModel = mocker.CreateInstance<RoomViewModel>();
+
+        viewModel.AutoShowVotes = true;
+
+        mocker.Verify<IRoomHubConnection>(x => x.UpdateRoomAsync(It.Is<RoomOptions>(o => o.AutoShowVotes == true)), Times.Once);
     }
 
     [Fact]

--- a/Tests/PointerStar.Server.Tests/PointerStar.Server.Tests.csproj
+++ b/Tests/PointerStar.Server.Tests/PointerStar.Server.Tests.csproj
@@ -6,14 +6,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.1" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.4.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\PointerStar\Server\PointerStar.Server.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.4.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This only applies to team member votes. When a vote is submitted and all team members have voted, it automatically reveals votes.

Fixes #12