### PR TITLE
Improve frontend retry resilience and ignore Playwright artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -274,6 +274,7 @@ FakesAssemblies/
 # Node.js Tools for Visual Studio
 .ntvs_analysis.dat
 node_modules/
+.playwright-mcp/
 
 # Visual Studio 6 build log
 *.plg

--- a/PointerStar/ClientApp/src/services/clientConfig.test.ts
+++ b/PointerStar/ClientApp/src/services/clientConfig.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { loadClientConfig } from './clientConfig'
+
+describe('clientConfig', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('retries transient client configuration failures before succeeding', async () => {
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          appVersion: '1.2.3',
+          applicationInsightsConnectionString: 'InstrumentationKey=abc',
+        }), {
+          headers: { 'Content-Type': 'application/json' },
+          status: 200,
+        }),
+      )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const configPromise = loadClientConfig()
+
+    await vi.runAllTimersAsync()
+
+    await expect(configPromise).resolves.toEqual({
+      appVersion: '1.2.3',
+      applicationInsightsConnectionString: 'InstrumentationKey=abc',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns null after exhausting retries', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const configPromise = loadClientConfig()
+
+    await vi.runAllTimersAsync()
+
+    await expect(configPromise).resolves.toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+})

--- a/PointerStar/ClientApp/src/services/clientConfig.ts
+++ b/PointerStar/ClientApp/src/services/clientConfig.ts
@@ -1,12 +1,19 @@
 import type { ClientConfig } from '../types/contracts'
+import { fetchWithRetry } from './retry'
+
+const clientConfigRetryOptions = {
+  baseDelayMs: 300,
+  maxAttempts: 4,
+  maxDelayMs: 2_000,
+}
 
 export async function loadClientConfig(): Promise<ClientConfig | null> {
   try {
-    const response = await fetch('/api/client-config', {
+    const response = await fetchWithRetry('/api/client-config', {
       headers: {
         Accept: 'application/json',
       },
-    })
+    }, clientConfigRetryOptions)
 
     if (!response.ok) {
       console.warn(`Unable to load client configuration: ${response.status} ${response.statusText}`)

--- a/PointerStar/ClientApp/src/services/retry.ts
+++ b/PointerStar/ClientApp/src/services/retry.ts
@@ -1,0 +1,127 @@
+export interface RetryContext {
+  attempt: number
+  delayMs: number
+  error: unknown
+}
+
+export interface RetryWithJitterOptions {
+  baseDelayMs?: number
+  jitterRatio?: number
+  maxAttempts?: number
+  maxDelayMs?: number
+  onRetry?: (context: RetryContext) => void
+  random?: () => number
+  shouldRetry?: (error: unknown) => boolean
+  signal?: AbortSignal
+  sleep?: (delayMs: number, signal?: AbortSignal) => Promise<void>
+}
+
+const transientStatusCodes = new Set([408, 425, 429, 500, 502, 503, 504])
+
+export class RetryableRequestError extends Error {
+  public readonly status: number
+
+  public constructor(message: string, status: number) {
+    super(message)
+    this.name = 'RetryableRequestError'
+    this.status = status
+  }
+}
+
+export function isAbortError(error: unknown) {
+  return error instanceof DOMException && error.name === 'AbortError'
+}
+
+export function waitForDelay(delayMs: number, signal?: AbortSignal) {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('The retry was cancelled.', 'AbortError'))
+      return
+    }
+
+    let timeoutId: ReturnType<typeof globalThis.setTimeout>
+    const onAbort = () => {
+      globalThis.clearTimeout(timeoutId)
+      signal?.removeEventListener('abort', onAbort)
+      reject(new DOMException('The retry was cancelled.', 'AbortError'))
+    }
+
+    timeoutId = globalThis.setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, delayMs)
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+export function getJitteredDelayMs(
+  attempt: number,
+  {
+    baseDelayMs = 300,
+    jitterRatio = 0.3,
+    maxDelayMs = 3_000,
+    random = Math.random,
+  }: Pick<RetryWithJitterOptions, 'baseDelayMs' | 'jitterRatio' | 'maxDelayMs' | 'random'> = {},
+) {
+  const delayMs = Math.min(maxDelayMs, baseDelayMs * 2 ** Math.max(0, attempt - 1))
+  const jitterWindow = Math.max(1, Math.round(delayMs * jitterRatio))
+  const jitterOffset = Math.round((random() * 2 - 1) * jitterWindow)
+  return Math.max(0, delayMs + jitterOffset)
+}
+
+export async function retryWithJitter<T>(
+  operation: () => Promise<T>,
+  options: RetryWithJitterOptions = {},
+) {
+  const {
+    maxAttempts = 4,
+    onRetry,
+    shouldRetry = () => true,
+    signal,
+    sleep = waitForDelay,
+  } = options
+
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await operation()
+    } catch (error) {
+      if (isAbortError(error) || !shouldRetry(error) || attempt >= maxAttempts) {
+        throw error
+      }
+
+      const delayMs = getJitteredDelayMs(attempt, options)
+      onRetry?.({ attempt, delayMs, error })
+      await sleep(delayMs, signal)
+    }
+  }
+}
+
+export function isTransientHttpStatus(status: number) {
+  return transientStatusCodes.has(status)
+}
+
+function isRetryableFetchError(error: unknown) {
+  return error instanceof RetryableRequestError || error instanceof TypeError
+}
+
+export function fetchWithRetry(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  options?: RetryWithJitterOptions,
+) {
+  return retryWithJitter(async () => {
+    const response = await fetch(input, init)
+    if (!response.ok && isTransientHttpStatus(response.status)) {
+      throw new RetryableRequestError(
+        `Transient request failure: ${response.status} ${response.statusText}`,
+        response.status,
+      )
+    }
+
+    return response
+  }, {
+    ...options,
+    shouldRetry: options?.shouldRetry ?? isRetryableFetchError,
+  })
+}

--- a/PointerStar/ClientApp/src/services/roomApi.test.ts
+++ b/PointerStar/ClientApp/src/services/roomApi.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { roles } from '../types/contracts'
+import { generateRoomId, getNewUserRole } from './roomApi'
+
+describe('roomApi', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('retries transient room generation failures', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response('', { status: 503, statusText: 'Service Unavailable' }))
+      .mockResolvedValueOnce(new Response('room-123', { status: 200 }))
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const roomIdPromise = generateRoomId()
+
+    await vi.runAllTimersAsync()
+
+    await expect(roomIdPromise).resolves.toBe('room-123')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry permanent room generation failures', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValue(new Response('', { status: 404, statusText: 'Not Found' }))
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(generateRoomId()).rejects.toThrow('Unable to generate a room: 404 Not Found')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries transient default role lookups', async () => {
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          id: roles.facilitator.id,
+          name: roles.facilitator.name,
+        }), {
+          headers: { 'Content-Type': 'application/json' },
+          status: 200,
+        }),
+      )
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const rolePromise = getNewUserRole('room-123')
+
+    await vi.runAllTimersAsync()
+
+    await expect(rolePromise).resolves.toEqual(roles.facilitator)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/PointerStar/ClientApp/src/services/roomApi.ts
+++ b/PointerStar/ClientApp/src/services/roomApi.ts
@@ -1,4 +1,11 @@
 import { roleFromId } from '../types/contracts'
+import { fetchWithRetry } from './retry'
+
+const requestRetryOptions = {
+  baseDelayMs: 300,
+  maxAttempts: 4,
+  maxDelayMs: 3_000,
+}
 
 async function readJson<T>(response: Response): Promise<T> {
   if (!response.ok) {
@@ -9,7 +16,7 @@ async function readJson<T>(response: Response): Promise<T> {
 }
 
 export async function generateRoomId() {
-  const response = await fetch('/api/room/generate')
+  const response = await fetchWithRetry('/api/room/generate', undefined, requestRetryOptions)
   if (!response.ok) {
     throw new Error(`Unable to generate a room: ${response.status} ${response.statusText}`)
   }
@@ -18,11 +25,11 @@ export async function generateRoomId() {
 }
 
 export async function getNewUserRole(roomId: string) {
-  const response = await fetch(`/api/room/GetNewUserRole/${encodeURIComponent(roomId)}`, {
+  const response = await fetchWithRetry(`/api/room/GetNewUserRole/${encodeURIComponent(roomId)}`, {
     headers: {
       Accept: 'application/json',
     },
-  })
+  }, requestRetryOptions)
 
   const role = await readJson<{ id: string; name: string }>(response)
   return roleFromId(role.id) ?? role

--- a/PointerStar/ClientApp/src/services/roomHubClient.ts
+++ b/PointerStar/ClientApp/src/services/roomHubClient.ts
@@ -6,22 +6,12 @@ import {
 
 import type { RoomOptions, RoomState, User, UserOptions } from '../types/contracts'
 import { roomHubMethods } from '../types/contracts'
+import { getJitteredDelayMs, waitForDelay } from './retry'
 
-const pauseBetweenFailuresMs = 20_000
-
-function waitForRetry(signal?: AbortSignal) {
-  return new Promise<void>((resolve, reject) => {
-    const timeoutId = window.setTimeout(resolve, pauseBetweenFailuresMs)
-
-    signal?.addEventListener(
-      'abort',
-      () => {
-        window.clearTimeout(timeoutId)
-        reject(new DOMException('The connection retry was cancelled.', 'AbortError'))
-      },
-      { once: true },
-    )
-  })
+const hubRetryOptions = {
+  baseDelayMs: 500,
+  jitterRatio: 0.25,
+  maxDelayMs: 10_000,
 }
 
 export class RoomHubClient {
@@ -49,6 +39,8 @@ export class RoomHubClient {
   }
 
   public async open(signal?: AbortSignal) {
+    let failedAttempts = 0
+
     while (!signal?.aborted) {
       if (
         this.connection.state === HubConnectionState.Connected ||
@@ -62,8 +54,10 @@ export class RoomHubClient {
         await this.connection.start()
         return
       } catch (error) {
-        console.warn('Unable to connect to the room hub. Retrying.', error)
-        await waitForRetry(signal)
+        failedAttempts += 1
+        const delayMs = getJitteredDelayMs(failedAttempts, hubRetryOptions)
+        console.warn(`Unable to connect to the room hub. Retrying in ${delayMs}ms.`, error)
+        await waitForDelay(delayMs, signal)
       }
     }
   }


### PR DESCRIPTION
Transient startup failures were surfacing too eagerly in the UI, especially when the backend was still waking up or a first request hit a brief network blip. This makes the frontend more tolerant of those short-lived failures by adding bounded jittered retry behavior around the initial API calls and first hub connection attempt.

## Summary
- add a shared retry helper for transient fetch failures with jittered backoff
- apply retries to client config loading, room creation, and default role lookup
- replace the fixed initial SignalR reconnect delay with jittered retry timing
- add frontend tests covering transient retries and permanent failure behavior
- ignore `.playwright-mcp/` artifacts in git

## Notes
- fetch-based retries are bounded, while the initial hub connection still keeps retrying until the page is torn down
- the existing GitHub Actions build workflow already runs `npm run test:run` in `PointerStar/ClientApp`, so the new frontend tests are covered by CI
- no PR template was present under `.github/`, so this uses a freeform description