### PR TITLE
Show hour-long vote timers as h:mm:ss

### DIFF
--- a/PointerStar/ClientApp/src/pages/RoomPage.tsx
+++ b/PointerStar/ClientApp/src/pages/RoomPage.tsx
@@ -54,6 +54,7 @@ import {
   type User,
   type UserOptions,
 } from '../types/contracts'
+import { getElapsedTimeLabel } from './roomTime'
 
 function isAbortError(error: unknown) {
   return error instanceof DOMException && error.name === 'AbortError'
@@ -61,22 +62,6 @@ function isAbortError(error: unknown) {
 
 function isRole(user: User | null | undefined, role: Role) {
   return user?.role.id === role.id
-}
-
-function getElapsedTimeLabel(startAt?: string | null, offsetMs = 0) {
-  if (!startAt) {
-    return ''
-  }
-
-  const elapsedMs = Math.max(0, Date.now() + offsetMs - new Date(startAt).getTime())
-  const minutes = Math.floor(elapsedMs / 60_000)
-    .toString()
-    .padStart(2, '0')
-  const seconds = Math.floor((elapsedMs % 60_000) / 1_000)
-    .toString()
-    .padStart(2, '0')
-
-  return `${minutes}:${seconds}`
 }
 
 export function RoomPage() {

--- a/PointerStar/ClientApp/src/pages/roomTime.test.ts
+++ b/PointerStar/ClientApp/src/pages/roomTime.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getElapsedTimeLabel } from './roomTime'
+
+describe('roomTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-07T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns an empty label when the timer has not started', () => {
+    expect(getElapsedTimeLabel()).toBe('')
+  })
+
+  it('shows minutes and seconds for timers under an hour', () => {
+    expect(getElapsedTimeLabel('2026-04-07T11:58:55Z')).toBe('01:05')
+  })
+
+  it('shows hours, minutes, and seconds for timers longer than an hour', () => {
+    expect(getElapsedTimeLabel('2026-04-07T10:58:55Z')).toBe('1:01:05')
+  })
+
+  it('applies the server clock offset to the elapsed time', () => {
+    expect(getElapsedTimeLabel('2026-04-07T11:59:30Z', 5_000)).toBe('00:35')
+  })
+})

--- a/PointerStar/ClientApp/src/pages/roomTime.ts
+++ b/PointerStar/ClientApp/src/pages/roomTime.ts
@@ -1,0 +1,24 @@
+export function getElapsedTimeLabel(startAt?: string | null, offsetMs = 0) {
+  if (!startAt) {
+    return ''
+  }
+
+  const elapsedMs = Math.max(0, Date.now() + offsetMs - new Date(startAt).getTime())
+  const totalSeconds = Math.floor(elapsedMs / 1_000)
+  const hours = Math.floor(totalSeconds / 3_600)
+  const seconds = (totalSeconds % 60).toString().padStart(2, '0')
+
+  if (hours > 0) {
+    const minutes = Math.floor((totalSeconds % 3_600) / 60)
+      .toString()
+      .padStart(2, '0')
+
+    return `${hours}:${minutes}:${seconds}`
+  }
+
+  const minutes = Math.floor(totalSeconds / 60)
+    .toString()
+    .padStart(2, '0')
+
+  return `${minutes}:${seconds}`
+}


### PR DESCRIPTION
Vote timers currently stay in `mm:ss`, which makes long-running votes read like `517:00` instead of an hours-based clock. This updates the room timer to switch to `h:mm:ss` once a vote has been running for at least an hour while keeping the existing display for shorter timers.

## What changed
- extracted elapsed-time formatting from `RoomPage` into a small `roomTime` helper
- format timers under an hour as `mm:ss` and hour-long timers as `h:mm:ss`
- added focused Vitest coverage for empty, sub-hour, hour-plus, and server-offset cases

## Testing
- `npm run test:run --prefix PointerStar/ClientApp`
- `npm run build --prefix PointerStar/ClientApp`
- `dotnet test --configuration Release`