### PR TITLE
Fix automerge job to wait for build to pass

### DIFF
--- a/.github/workflows/main_pointerstar.yml
+++ b/.github/workflows/main_pointerstar.yml
@@ -82,6 +82,7 @@ jobs:
 
   automerge:
     if: ${{ github.event_name == 'pull_request' }}
+    needs: build
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
The `automerge` job was running in parallel with `build`, so it tried to enable auto-merge before the build had a chance to run or pass. This meant Dependabot PRs were never actually auto-merged.

Adding `needs: build` ensures the job only runs after a successful build, which is the prerequisite for GitHub's native auto-merge to activate and complete.

**Note:** For auto-merge to work end-to-end, the GitHub repo settings also need:
- **Settings -> General -> Allow auto-merge** enabled
- **Settings -> Branches -> Branch protection on `main`** with `build` as a required status check