### PR TITLE
Default AutoShowVotes to false

### DIFF
--- a/PointerStar/Shared/RoomState.cs
+++ b/PointerStar/Shared/RoomState.cs
@@ -12,8 +12,7 @@ public sealed record class RoomState(string RoomId, User[] Users)
         => [.. Users.Where(u => u.Role == Role.Observer)];
 
     public bool VotesShown { get; init; }
-    //We want the default to be true so new facilitators have this on by default
-    public bool AutoShowVotes { get; init; } = true;
+    public bool AutoShowVotes { get; init; }
 
     public string[] VoteOptions { get; init; } = VotingPresets.Fibonacci;
     public DateTime? VoteStartTime { get; init; } = DateTime.UtcNow;

--- a/Tests/PointerStar.Server.Tests/Room/RoomManagerTests.cs
+++ b/Tests/PointerStar.Server.Tests/Room/RoomManagerTests.cs
@@ -24,7 +24,7 @@ public abstract class RoomManagerTests<TRoomManager>
         Assert.Single(roomState.Users);
         //First user is the room is made the facilitator
         Assert.Equal(user with { Role = Role.Facilitator }, roomState.Users[0]);
-        Assert.True(roomState.AutoShowVotes);
+        Assert.False(roomState.AutoShowVotes);
     }
 
     [Fact]
@@ -269,7 +269,7 @@ public abstract class RoomManagerTests<TRoomManager>
         }, connectionId2);
 
         Assert.False(roomState?.VotesShown);
-        Assert.True(roomState!.AutoShowVotes);
+        Assert.False(roomState!.AutoShowVotes);
     }
 
     [Fact]


### PR DESCRIPTION
Previously, new rooms defaulted to automatically revealing votes as soon as all team members had voted (`AutoShowVotes = true`). This change flips that default to `false` so votes remain hidden until a facilitator explicitly shows them or enables auto-show.

This gives facilitators more control over the reveal moment, which is often a deliberate part of the pointing exercise.