### PR TITLE
Smooth SignalR disconnections for backgrounded browser tabs

### DIFF
--- a/PointerStar/ClientApp/src/pages/RoomPage.tsx
+++ b/PointerStar/ClientApp/src/pages/RoomPage.tsx
@@ -44,6 +44,7 @@ import {
 } from '../services/cookies'
 import { addRecentRoom } from '../services/recentRooms'
 import { RoomHubClient } from '../services/roomHubClient'
+import { getOrCreateUserId } from '../services/userIdentity'
 import {
   defaultVoteOptions,
   roleFromId,
@@ -96,6 +97,18 @@ export function RoomPage() {
 
   const clientRef = useRef<RoomHubClient | null>(null)
   const lastProcessedResetAtRef = useRef<string | null>(null)
+
+  // Refs for latest values needed inside stable callbacks (avoid stale closures).
+  const nameRef = useRef(name)
+  const selectedRoleIdRef = useRef(selectedRoleId)
+
+  useEffect(() => {
+    nameRef.current = name
+  }, [name])
+
+  useEffect(() => {
+    selectedRoleIdRef.current = selectedRoleId
+  }, [selectedRoleId])
 
   const currentUser = useMemo(
     () => roomState?.users.find((user) => user.id === currentUserId) ?? null,
@@ -193,7 +206,7 @@ export function RoomPage() {
           const role = roleFromId(nextRoleId) ?? roles.teamMember
           const resolvedName = nextName.trim() || `User ${Math.floor(Math.random() * 100_000)}`
           const user: User = {
-            id: crypto.randomUUID(),
+            id: getOrCreateUserId(),
             name: resolvedName,
             role,
           }
@@ -271,6 +284,28 @@ export function RoomPage() {
 
     let cancelled = false
 
+    // Rejoins the room using the stable user identity. Called by:
+    //   - onreconnected (SignalR built-in reconnect succeeded)
+    //   - onclose (reconnect exhausted; this also re-opens the connection)
+    //   - visibilitychange (tab foregrounded while fully disconnected)
+    const rejoinRoom = async () => {
+      try {
+        await client.open(controller.signal)
+        const userId = getOrCreateUserId()
+        const resolvedName = nameRef.current
+        if (!resolvedName || !roomId) return
+        const role = roleFromId(selectedRoleIdRef.current) ?? roles.teamMember
+        const user: User = { id: userId, name: resolvedName, role }
+        await callHub((roomClient) => roomClient.joinRoom(roomId, user))
+      } catch (error) {
+        if (!isAbortError(error)) {
+          console.error('Failed to rejoin room after reconnect.', error)
+        }
+      }
+    }
+
+    client.setReconnectHandler(rejoinRoom)
+
     void (async () => {
       try {
         await client.open(controller.signal)
@@ -294,7 +329,7 @@ export function RoomPage() {
       }
 
       const rememberedName = preferredName || getStoredName()
-      if (rememberedName && !name) {
+      if (rememberedName && !nameRef.current) {
         setName(rememberedName)
       }
 
@@ -304,7 +339,7 @@ export function RoomPage() {
 
       if (rememberedRoomId === roomId && rememberedRole && rememberedName.trim()) {
         const user: User = {
-          id: crypto.randomUUID(),
+          id: getOrCreateUserId(),
           name: rememberedName,
           role: rememberedRole,
         }
@@ -322,16 +357,26 @@ export function RoomPage() {
       }
     })()
 
+    const handleVisibilityChange = async () => {
+      if (document.visibilityState !== 'visible') return
+      // Only act when fully disconnected; Reconnecting is already being handled by SignalR.
+      if (!client.isDisconnected) return
+      await rejoinRoom()
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
     return () => {
       cancelled = true
       controller.abort()
       unsubscribe()
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
       void client.stop()
       if (clientRef.current === client) {
         clientRef.current = null
       }
     }
-  }, [callHub, name, preferredName, roomId, showSnackbar])
+  }, [callHub, preferredName, roomId, showSnackbar])
 
   useEffect(() => {
     const intervalId = window.setInterval(() => {

--- a/PointerStar/ClientApp/src/services/roomHubClient.ts
+++ b/PointerStar/ClientApp/src/services/roomHubClient.ts
@@ -17,6 +17,7 @@ const hubRetryOptions = {
 export class RoomHubClient {
   private readonly connection: HubConnection
   private readonly roomStateListeners = new Set<(roomState: RoomState) => void>()
+  private reconnectHandler?: () => Promise<void>
 
   public constructor(url = `${window.location.origin}/RoomHub`) {
     this.connection = new HubConnectionBuilder().withUrl(url).withAutomaticReconnect().build()
@@ -24,10 +25,35 @@ export class RoomHubClient {
     this.connection.on(roomHubMethods.roomUpdated, (roomState: RoomState) => {
       this.roomStateListeners.forEach((listener) => listener(roomState))
     })
+
+    // Re-join room after SignalR's built-in reconnect restores the transport.
+    this.connection.onreconnected(() => {
+      void this.reconnectHandler?.()
+    })
+
+    // Re-join room after all automatic reconnect attempts are exhausted.
+    // The handler will call open() to start a new connection loop then rejoin.
+    this.connection.onclose(() => {
+      void this.reconnectHandler?.()
+    })
   }
 
   public get isConnected() {
     return this.connection.state === HubConnectionState.Connected
+  }
+
+  /** True when the connection is fully stopped (not Connecting or Reconnecting). */
+  public get isDisconnected() {
+    return this.connection.state === HubConnectionState.Disconnected
+  }
+
+  /**
+   * Registers a handler that is called whenever the connection is restored
+   * (after automatic reconnect or after a cold re-open). The handler should
+   * re-join the room using the last-known user identity.
+   */
+  public setReconnectHandler(handler: () => Promise<void>) {
+    this.reconnectHandler = handler
   }
 
   public subscribe(listener: (roomState: RoomState) => void) {

--- a/PointerStar/ClientApp/src/services/userIdentity.ts
+++ b/PointerStar/ClientApp/src/services/userIdentity.ts
@@ -1,0 +1,15 @@
+const USER_ID_KEY = 'pointerstar-user-id'
+
+/**
+ * Returns a stable user UUID for this browser tab session.
+ * Creates and persists a new UUID in sessionStorage on first call.
+ * Cleared when the tab is closed, so each new tab gets a fresh identity.
+ */
+export function getOrCreateUserId(): string {
+  let userId = sessionStorage.getItem(USER_ID_KEY)
+  if (!userId) {
+    userId = crypto.randomUUID()
+    sessionStorage.setItem(USER_ID_KEY, userId)
+  }
+  return userId
+}

--- a/PointerStar/Server/Hubs/RoomHub.cs
+++ b/PointerStar/Server/Hubs/RoomHub.cs
@@ -15,11 +15,10 @@ public class RoomHub : Hub
 
     public override async Task OnDisconnectedAsync(Exception? exception)
     {
-        RoomState? room = await RoomManager.DisconnectAsync(Context.ConnectionId);
-        if (room?.RoomId is { } roomId)
+        if (RoomManager.TryReleaseConnection(Context.ConnectionId, out string? roomId, out Guid userId) &&
+            roomId is not null)
         {
-            string normalizedRoomId = NormalizeRoomId(roomId);
-            await Clients.Group(normalizedRoomId).SendAsync(RoomHubConnection.RoomUpdatedMethodName, room);
+            await RoomManager.ScheduleDisconnectAsync(userId, roomId, TimeSpan.FromSeconds(30));
         }
         await base.OnDisconnectedAsync(exception);
     }
@@ -27,6 +26,7 @@ public class RoomHub : Hub
     [HubMethodName(RoomHubConnection.JoinRoomMethodName)]
     public async Task JoinRoomAsync(string roomId, User user)
     {
+        RoomManager.CancelPendingDisconnect(user.Id);
         string normalizedRoomId = NormalizeRoomId(roomId);
         RoomState roomState = await RoomManager.AddUserToRoomAsync(roomId, user, Context.ConnectionId);
         await Groups.AddToGroupAsync(Context.ConnectionId, normalizedRoomId);

--- a/PointerStar/Server/Program.cs
+++ b/PointerStar/Server/Program.cs
@@ -31,7 +31,7 @@ builder.Services.AddSignalR(hubOptions => hubOptions.EnableDetailedErrors = true
                     options =>
                     {
                         options.KeepAliveInterval = TimeSpan.FromSeconds(15);
-                        options.ClientTimeoutInterval = TimeSpan.FromMinutes(1);
+                        options.ClientTimeoutInterval = TimeSpan.FromMinutes(3);
                     });
 
 builder.Services.AddScoped(_ => new Hashids("TODO: Environment Salt"));

--- a/PointerStar/Server/Room/IRoomManager.cs
+++ b/PointerStar/Server/Room/IRoomManager.cs
@@ -6,6 +6,9 @@ public interface IRoomManager
 {
     Task<RoomState> AddUserToRoomAsync(string roomId, User user, string connectionId);
     Task<RoomState?> DisconnectAsync(string connectionId);
+    bool TryReleaseConnection(string connectionId, out string? roomId, out Guid userId);
+    Task ScheduleDisconnectAsync(Guid userId, string roomId, TimeSpan delay);
+    void CancelPendingDisconnect(Guid userId);
     Task<RoomState?> UpdateRoomAsync(RoomOptions roomOptions, string connectionId);
     Task<RoomState?> UpdateUserAsync(UserOptions userOptions, string connectionId);
     Task<RoomState?> SubmitVoteAsync(string vote, string connectionId);

--- a/PointerStar/Server/Room/InMemoryRoomManager.cs
+++ b/PointerStar/Server/Room/InMemoryRoomManager.cs
@@ -1,6 +1,9 @@
-﻿using PointerStar.Shared;
-using Microsoft.ApplicationInsights;
+﻿using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using PointerStar.Server.Hubs;
+using PointerStar.Shared;
 
 namespace PointerStar.Server.Room;
 public class InMemoryRoomManager : IRoomManager
@@ -9,11 +12,16 @@ public class InMemoryRoomManager : IRoomManager
     private ConcurrentDictionary<string, RoomState> Rooms { get; } = new();
     private ConcurrentDictionary<string, string> ConnectionsToRoom { get; } = new();
     private ConcurrentDictionary<string, Guid> ConnectionsToUserId { get; } = new();
+    private ConcurrentDictionary<Guid, CancellationTokenSource> PendingDisconnects { get; } = new();
     private TelemetryClient TelemetryClient { get; }
+    private IHubContext<RoomHub> HubContext { get; }
+    private ILogger<InMemoryRoomManager> Logger { get; }
 
-    public InMemoryRoomManager(TelemetryClient telemetryClient)
+    public InMemoryRoomManager(TelemetryClient telemetryClient, IHubContext<RoomHub> hubContext, ILogger<InMemoryRoomManager> logger)
     {
         TelemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+        HubContext = hubContext ?? throw new ArgumentNullException(nameof(hubContext));
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public Task<RoomState> AddUserToRoomAsync(string roomId, User user, string connectionId)
@@ -91,6 +99,55 @@ public class InMemoryRoomManager : IRoomManager
             }
             return null;
         });
+    }
+
+    public bool TryReleaseConnection(string connectionId, out string? roomId, out Guid userId)
+    {
+        bool hadRoom = ConnectionsToRoom.TryRemove(connectionId, out roomId);
+        bool hadUser = ConnectionsToUserId.TryRemove(connectionId, out userId);
+        return hadRoom && hadUser;
+    }
+
+    public Task ScheduleDisconnectAsync(Guid userId, string roomId, TimeSpan delay)
+    {
+        CancelPendingDisconnect(userId);
+
+        var cts = new CancellationTokenSource();
+        PendingDisconnects[userId] = cts;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(delay, cts.Token);
+                RoomState? room = await RemoveUserFromRoomAsync(NormalizeRoomId(roomId), userId);
+                if (room is not null)
+                {
+                    await HubContext.Clients.Group(NormalizeRoomId(room.RoomId))
+                        .SendAsync(RoomHubConnection.RoomUpdatedMethodName, room);
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error during deferred disconnect for user {UserId} in room {RoomId}", userId, roomId);
+            }
+            finally
+            {
+                PendingDisconnects.TryRemove(userId, out _);
+            }
+        });
+
+        return Task.CompletedTask;
+    }
+
+    public void CancelPendingDisconnect(Guid userId)
+    {
+        if (PendingDisconnects.TryRemove(userId, out CancellationTokenSource? cts))
+        {
+            cts.Cancel();
+            cts.Dispose();
+        }
     }
 
     public Task<RoomState?> UpdateRoomAsync(RoomOptions roomOptions, string connectionId)
@@ -288,6 +345,28 @@ public class InMemoryRoomManager : IRoomManager
         });
     }
 
+
+    private Task<RoomState?> RemoveUserFromRoomAsync(string roomId, Guid userId)
+    {
+        return WithExistingRoom(roomId, userId, (room, currentUser) =>
+        {
+            User[] users = [..room.Users.Where(x => x.Id != currentUser.Id)];
+
+            TelemetryClient?.TrackEvent("UserDisconnected", new Dictionary<string, string>
+            {
+                { "RoomId", room.RoomId },
+                { "UserId", currentUser.Id.ToString() },
+                { "UserRole", currentUser.Role.Name }
+            });
+
+            if (users.Length != 0)
+            {
+                TelemetryClient?.GetMetric("RoomUserCount", "RoomId").TrackValue(users.Length, room.RoomId);
+                return room with { Users = users };
+            }
+            return null;
+        });
+    }
 
     private Task<RoomState?> WithConnection(string connectionId, Func<RoomState, User, RoomState?> updateRoom)
     {

--- a/Tests/PointerStar.Server.Tests/Room/InMemoryRoomManagerTests.cs
+++ b/Tests/PointerStar.Server.Tests/Room/InMemoryRoomManagerTests.cs
@@ -1,4 +1,8 @@
-﻿using PointerStar.Server.Room;
+﻿using Microsoft.AspNetCore.SignalR;
+using Moq;
+using PointerStar.Server.Hubs;
+using PointerStar.Server.Room;
+using PointerStar.Shared;
 
 namespace PointerStar.Server.Tests.Room;
 
@@ -6,5 +10,109 @@ namespace PointerStar.Server.Tests.Room;
 public partial class InMemoryRoomManagerTests : RoomManagerTests<InMemoryRoomManager>
 {
     partial void AutoMockerTestSetup(AutoMocker mocker, string testName)
-        => mocker.WithApplicationInsights();
+    {
+        mocker.WithApplicationInsights();
+        SetupHubContext(mocker);
+    }
+
+    private static void SetupHubContext(AutoMocker mocker)
+    {
+        var mockClientProxy = new Mock<IClientProxy>();
+        mockClientProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var mockHubClients = new Mock<IHubClients>();
+        mockHubClients.Setup(x => x.Group(It.IsAny<string>())).Returns(mockClientProxy.Object);
+
+        mocker.GetMock<IHubContext<RoomHub>>().Setup(x => x.Clients).Returns(mockHubClients.Object);
+    }
+
+    [Fact]
+    public async Task TryReleaseConnection_WithConnectedUser_RemovesConnectionAndReturnsRoomAndUser()
+    {
+        AutoMocker mocker = new();
+        mocker.WithApplicationInsights();
+        SetupHubContext(mocker);
+
+        string connectionId = Guid.NewGuid().ToString();
+        string teamMember = Guid.NewGuid().ToString();
+        IRoomManager sut = mocker.CreateInstance<InMemoryRoomManager>();
+        RoomState room = await CreateRoom(sut, connectionId, teamMember);
+        User connectedUser = room.Users[0];
+
+        bool result = sut.TryReleaseConnection(connectionId, out string? roomId, out Guid userId);
+
+        Assert.True(result);
+        Assert.NotNull(roomId);
+        Assert.Equal(connectedUser.Id, userId);
+    }
+
+    [Fact]
+    public void TryReleaseConnection_WithUnknownConnection_ReturnsFalse()
+    {
+        AutoMocker mocker = new();
+        mocker.WithApplicationInsights();
+        SetupHubContext(mocker);
+
+        IRoomManager sut = mocker.CreateInstance<InMemoryRoomManager>();
+
+        bool result = sut.TryReleaseConnection(Guid.NewGuid().ToString(), out string? roomId, out Guid userId);
+
+        Assert.False(result);
+        Assert.Null(roomId);
+        Assert.Equal(Guid.Empty, userId);
+    }
+
+    [Fact]
+    public async Task ScheduleDisconnectAsync_AfterDelay_RemovesUserFromRoom()
+    {
+        AutoMocker mocker = new();
+        mocker.WithApplicationInsights();
+        SetupHubContext(mocker);
+
+        string connectionId = Guid.NewGuid().ToString();
+        string teamMemberConnectionId = Guid.NewGuid().ToString();
+        IRoomManager sut = mocker.CreateInstance<InMemoryRoomManager>();
+        RoomState room = await CreateRoom(sut, connectionId, teamMemberConnectionId);
+        User facilitator = room.Users.First(u => u.Role == Role.Facilitator);
+
+        sut.TryReleaseConnection(connectionId, out string? roomId, out Guid userId);
+        Assert.NotNull(roomId);
+
+        await sut.ScheduleDisconnectAsync(userId, roomId, TimeSpan.FromMilliseconds(50));
+        await Task.Delay(500);
+
+        // After the grace period, the facilitator should be removed.
+        // Disconnecting the team member now leaves an empty room (returns null).
+        RoomState? roomAfter = await sut.DisconnectAsync(teamMemberConnectionId);
+        Assert.Null(roomAfter?.Users.FirstOrDefault(u => u.Id == facilitator.Id));
+    }
+
+    [Fact]
+    public async Task CancelPendingDisconnect_BeforeDelay_KeepsUserInRoom()
+    {
+        AutoMocker mocker = new();
+        mocker.WithApplicationInsights();
+        SetupHubContext(mocker);
+
+        string connectionId = Guid.NewGuid().ToString();
+        string teamMemberConnectionId = Guid.NewGuid().ToString();
+        IRoomManager sut = mocker.CreateInstance<InMemoryRoomManager>();
+        RoomState room = await CreateRoom(sut, connectionId, teamMemberConnectionId);
+        User facilitator = room.Users.First(u => u.Role == Role.Facilitator);
+
+        sut.TryReleaseConnection(connectionId, out string? roomId, out Guid userId);
+        Assert.NotNull(roomId);
+
+        await sut.ScheduleDisconnectAsync(userId, roomId, TimeSpan.FromMilliseconds(300));
+        sut.CancelPendingDisconnect(userId);
+        await Task.Delay(500);
+
+        // Grace period was cancelled so facilitator should still be in the room.
+        // Disconnecting the team member should return the room still containing the facilitator.
+        RoomState? roomAfter = await sut.DisconnectAsync(teamMemberConnectionId);
+        Assert.NotNull(roomAfter);
+        Assert.Contains(roomAfter.Users, u => u.Id == facilitator.Id);
+    }
 }


### PR DESCRIPTION
## Why

Planning poker sessions break when participants background their browser tab. Safari/iOS suspends JS almost immediately; Chrome throttles timers after ~5 minutes. With the previous 1-minute `ClientTimeoutInterval` and no reconnect-rejoin logic, users who backgrounded their tab appeared to leave the room -- losing their vote and requiring a full rejoin dialog.

## What changed

Five layered improvements work together to make the experience seamless:

**Stable user identity** (`userIdentity.ts`, `RoomPage.tsx`)
A new `getOrCreateUserId()` helper stores a UUID in `sessionStorage`. Both `crypto.randomUUID()` call sites in `RoomPage.tsx` are replaced with this, so a reconnecting user keeps the same ID and their vote is preserved via the server's existing upsert logic.

**Automatic rejoin on reconnect and tab-focus** (`roomHubClient.ts`, `RoomPage.tsx`)
`RoomHubClient` gains `setReconnectHandler()`, `isDisconnected`, and hooks for `onreconnected` and `onclose`. A single `rejoinRoom()` function in `RoomPage.tsx` handles all three recovery paths: SignalR's built-in reconnect, exhausted retries, and `visibilitychange`. The `visibilitychange` handler only fires when the connection is fully `Disconnected` so it doesn't race with an in-progress reconnect. `nameRef`/`selectedRoleIdRef` track latest values to avoid stale closures; `name` is removed from the main `useEffect` dependency array (it was causing a full client teardown every time the user typed their name).

**Longer client timeout** (`Program.cs`)
`ClientTimeoutInterval` raised from 1 to 3 minutes, giving mobile browsers more room before the server declares the client gone.

**30-second server-side grace period** (`IRoomManager.cs`, `InMemoryRoomManager.cs`, `RoomHub.cs`)
`IRoomManager` gains `TryReleaseConnection`, `ScheduleDisconnectAsync`, and `CancelPendingDisconnect`. `OnDisconnectedAsync` now releases the connection-map entries immediately but defers room-state removal by 30 seconds. `JoinRoomAsync` cancels any pending grace period before re-adding the user, so a reconnect within the window is transparent to other participants. `IHubContext<RoomHub>` is injected into `InMemoryRoomManager` (singleton, no circular dependency issue) to broadcast the deferred update; exceptions in the fire-and-forget task are caught and logged.

## Tests

5 new `InMemoryRoomManager` tests cover `TryReleaseConnection`, `ScheduleDisconnectAsync`, and `CancelPendingDisconnect`. All 53 existing .NET tests and all 15 frontend tests continue to pass.