### PR TITLE
Group Dependabot updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    groups:
+      nuget:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
@@ -11,5 +15,14 @@ updates:
       interval: "weekly"
     groups:
       github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/PointerStar/ClientApp" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    groups:
+      npm:
         patterns:
           - "*"

--- a/.github/workflows/main_pointerstar.yml
+++ b/.github/workflows/main_pointerstar.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v6
@@ -49,8 +50,11 @@ jobs:
       - name: dotnet build
         run: dotnet build --configuration Release -p:Version="${{ env.version }}"
 
-      - name: dotnet test
-        run: dotnet test --configuration Release --no-build --collect:"XPlat Code Coverage" --results-directory ./coverage
+      - name: dotnet test (shared)
+        run: dotnet test Tests/PointerStar.Shared.Tests/PointerStar.Shared.Tests.csproj --configuration Release --no-build --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      - name: dotnet test (server)
+        run: dotnet test Tests/PointerStar.Server.Tests/PointerStar.Server.Tests.csproj --configuration Release --no-build --collect:"XPlat Code Coverage" --results-directory ./coverage
 
       - name: ReportGenerator
         uses: danielpalme/ReportGenerator-GitHub-Action@5.5.10

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Moq.AutoMock" Version="4.0.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.11.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Moq.AutoMock" Version="4.0.2" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/PointerStar.slnx
+++ b/PointerStar.slnx
@@ -22,7 +22,10 @@
     <Project Path="Tests/PointerStar.Shared.Tests/PointerStar.Shared.Tests.csproj" />
   </Folder>
   <Project Path="PointerStar/AppHost/PointerStar.AppHost.csproj" />
-  <Project Path="PointerStar/ClientApp/PointerStar.ClientApp.esproj" />
+  <Project Path="PointerStar/ClientApp/PointerStar.ClientApp.esproj">
+    <Build />
+    <Deploy />
+  </Project>
   <Project Path="PointerStar/Server/PointerStar.Server.csproj" />
   <Project Path="PointerStar/Shared/PointerStar.Shared.csproj" />
 </Solution>

--- a/PointerStar/Server/PointerStar.Server.csproj
+++ b/PointerStar/Server/PointerStar.Server.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <Target Name="RestoreClientApp" BeforeTargets="Build" Condition="'$(EnableClientAppBuild)' == 'true' and !Exists('$(SpaRoot)node_modules')">
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm ci" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="pnpm install --frozen-lockfile" />
   </Target>
 
   <Target Name="BuildClientApp" BeforeTargets="Build" Condition="'$(EnableClientAppBuild)' == 'true'">

--- a/PointerStar/Server/Program.cs
+++ b/PointerStar/Server/Program.cs
@@ -8,11 +8,14 @@ using PointerStar.Server.Room;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-#if DEBUG
-builder.Services.AddSingleton<TelemetryClient>(x => new(TelemetryConfiguration.CreateDefault()));
-#else
-builder.Services.AddApplicationInsightsTelemetry();
-#endif
+if (builder.Environment.IsDevelopment())
+{
+    builder.Services.AddSingleton<TelemetryClient>(x => new(TelemetryConfiguration.CreateDefault()));
+}
+else
+{
+    builder.Services.AddApplicationInsightsTelemetry();
+}
 
 builder.Services.AddControllers();
 builder.Services.AddRazorPages();

--- a/Tests/PointerStar.Server.Tests/PointerStar.Server.Tests.csproj
+++ b/Tests/PointerStar.Server.Tests/PointerStar.Server.Tests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/PointerStar.Server.Tests/Room/InMemoryRoomManagerTests.cs
+++ b/Tests/PointerStar.Server.Tests/Room/InMemoryRoomManagerTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR;
 using Moq;
 using PointerStar.Server.Hubs;
 using PointerStar.Server.Room;
@@ -11,7 +11,7 @@ public partial class InMemoryRoomManagerTests : RoomManagerTests<InMemoryRoomMan
 {
     partial void AutoMockerTestSetup(AutoMocker mocker, string testName)
     {
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
         SetupHubContext(mocker);
     }
 
@@ -32,7 +32,7 @@ public partial class InMemoryRoomManagerTests : RoomManagerTests<InMemoryRoomMan
     public async Task TryReleaseConnection_WithConnectedUser_RemovesConnectionAndReturnsRoomAndUser()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
         SetupHubContext(mocker);
 
         string connectionId = Guid.NewGuid().ToString();
@@ -52,7 +52,7 @@ public partial class InMemoryRoomManagerTests : RoomManagerTests<InMemoryRoomMan
     public void TryReleaseConnection_WithUnknownConnection_ReturnsFalse()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
         SetupHubContext(mocker);
 
         IRoomManager sut = mocker.CreateInstance<InMemoryRoomManager>();
@@ -68,7 +68,7 @@ public partial class InMemoryRoomManagerTests : RoomManagerTests<InMemoryRoomMan
     public async Task ScheduleDisconnectAsync_AfterDelay_RemovesUserFromRoom()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
         SetupHubContext(mocker);
 
         string connectionId = Guid.NewGuid().ToString();
@@ -93,7 +93,7 @@ public partial class InMemoryRoomManagerTests : RoomManagerTests<InMemoryRoomMan
     public async Task CancelPendingDisconnect_BeforeDelay_KeepsUserInRoom()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
         SetupHubContext(mocker);
 
         string connectionId = Guid.NewGuid().ToString();

--- a/Tests/PointerStar.Server.Tests/Room/RoomManagerTests.cs
+++ b/Tests/PointerStar.Server.Tests/Room/RoomManagerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using PointerStar.Server.Room;
 using PointerStar.Shared;
 
@@ -7,11 +7,14 @@ namespace PointerStar.Server.Tests.Room;
 public abstract class RoomManagerTests<TRoomManager>
     where TRoomManager : class, IRoomManager
 {
+    protected static void UseTestTelemetry(AutoMocker mocker) =>
+        mocker.WithApplicationInsights();
+
     [Fact]
     public async Task AddUserToRoomAsync_WithNewRoom_CreatesNewRoom()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string roomId = Guid.NewGuid().ToString();
         string connectionId = Guid.NewGuid().ToString();
@@ -31,7 +34,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task AddUserToRoomAsync_WithUser_AddsToExistingRoom()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string roomId = Guid.NewGuid().ToString();
         User user1 = new(Guid.NewGuid(), "User 1") { Role = Role.Facilitator };
@@ -52,7 +55,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task AddUserToRoomAsync_WithUserWithLongName_TrimsUsersName()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string tooLongName = "User 1 this is a really, really, really, really, long name";
         string roomId = Guid.NewGuid().ToString();
@@ -71,7 +74,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task DisconnectAsync_WithMultipleConnectedUser_RemovesFromCurrentRoom()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string roomId = Guid.NewGuid().ToString();
         string connectionId1 = Guid.NewGuid().ToString();
@@ -93,7 +96,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task DisconnectAsync_WithLastConnectedUser_RemovesRoom()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string roomId = Guid.NewGuid().ToString();
         string connectionId = Guid.NewGuid().ToString();
@@ -110,7 +113,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task DisconnectAsync_WithDisconnectedUser_ReturnsNull()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string connectionId = Guid.NewGuid().ToString();
         IRoomManager sut = mocker.CreateInstance<TRoomManager>();
@@ -124,7 +127,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task SubmitVoteAsync_WithConnectedUser_UpdatesVote()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string roomId = Guid.NewGuid().ToString();
         string connectionId = Guid.NewGuid().ToString();
@@ -145,7 +148,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task SubmitVoteAsync_WithInvalidVoteOption_DoesNotUpdateVote()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string roomId = Guid.NewGuid().ToString();
         string connectionId = Guid.NewGuid().ToString();
@@ -166,7 +169,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task SubmitVoteAsync_AfterVotesShown_UpdatesVote()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         string teamMember1 = Guid.NewGuid().ToString();
@@ -188,7 +191,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task SubmitVoteAsync_WithAutoShowVotes_ShowsVotesWhenAllTeamMembersHaveVoted()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         string teamMember1 = Guid.NewGuid().ToString();
@@ -209,7 +212,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task SubmitVoteAsync_WithDisconnectedUser_ReturnsNull()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string connectionId = Guid.NewGuid().ToString();
         IRoomManager sut = mocker.CreateInstance<TRoomManager>();
@@ -229,7 +232,7 @@ public abstract class RoomManagerTests<TRoomManager>
         bool expectedVotesShown, bool expectedAutoShowVotes)
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string connectionId = Guid.NewGuid().ToString();
         IRoomManager sut = mocker.CreateInstance<TRoomManager>();
@@ -250,7 +253,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task UpdateRoomAsync_WithTeamMemberUser_DoesNotUpdateRoom()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string roomId = Guid.NewGuid().ToString();
         string connectionId1 = Guid.NewGuid().ToString();
@@ -277,7 +280,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task UpdateRoomAsync_WithAutoShowVotesAfterAllVotesCast_RevealsVotes()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         string teamMember1 = Guid.NewGuid().ToString();
@@ -297,7 +300,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task UpdateRoomAsync_HidingShownVotesWithAutoRevealEnabled_DisablesAutoRevealAndHidesVotes()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         string teamMember1 = Guid.NewGuid().ToString();
@@ -321,7 +324,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task UpdateUserAsync_WithName_UpdatesUsers()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         IRoomManager sut = mocker.CreateInstance<TRoomManager>();
@@ -339,7 +342,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task UpdateUserAsync_WithRole_UpdatesUser()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         IRoomManager sut = mocker.CreateInstance<TRoomManager>();
@@ -357,7 +360,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task UpdateUserAsync_WithNameTooLong_TrimsName()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string tooLongName = "User 1 this is a really, really, really, really, long name";
         string facilitator = Guid.NewGuid().ToString();
@@ -377,7 +380,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task ResetVotes_WithFacilitator_ClearsAllVotes()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
 
         string facilitator = Guid.NewGuid().ToString();
@@ -399,7 +402,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task ResetVotes_WithTeamMember_DoesNotReset()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         string teamMember = Guid.NewGuid().ToString();
@@ -420,7 +423,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task GetNewUserRoleAsync_WithNewRoom_ReturnsFacilitator()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         IRoomManager sut = mocker.CreateInstance<TRoomManager>();
 
@@ -433,7 +436,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task GetNewUserRoleAsync_WithoutFacilitatorsInTheRoom_ReturnsFacilitator()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         IRoomManager sut = mocker.CreateInstance<TRoomManager>();
         string roomId = Guid.NewGuid().ToString();
@@ -449,7 +452,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task GetNewUserRoleAsync_WithExistingFacilitator_ReturnsTeamMember()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         IRoomManager sut = mocker.CreateInstance<TRoomManager>();
         RoomState room = await CreateRoom(sut, Guid.NewGuid().ToString());
@@ -463,7 +466,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task ResetVotes_WithFacilitator_StopsVotingTimer()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         string teamMember = Guid.NewGuid().ToString();
@@ -480,7 +483,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task RemoveUserAsync_WithFacilitator_MovesTeamMemberToObserver()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         string teamMember = Guid.NewGuid().ToString();
@@ -499,7 +502,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task RemoveUserAsync_WithTeamMember_DoesNothing()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         string teamMember1 = Guid.NewGuid().ToString();
@@ -518,7 +521,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task RemoveUserAsync_WithUnknownUserId_DoesNothing()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         string teamMember = Guid.NewGuid().ToString();
@@ -535,7 +538,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task UpdateRoomAsync_WithVoteOptions_UpdatesVoteOptions()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
         string facilitator = Guid.NewGuid().ToString();
         IRoomManager sut = mocker.CreateInstance<TRoomManager>();
         await CreateRoom(sut, facilitator);
@@ -554,7 +557,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task UpdateRoomAsync_WithEmptyVoteOptions_DoesNotUpdateVoteOptions()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
         string facilitator = Guid.NewGuid().ToString();
         IRoomManager sut = mocker.CreateInstance<TRoomManager>();
         RoomState room = await CreateRoom(sut, facilitator);
@@ -573,7 +576,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task UpdateRoomAsync_WithVoteOptionsAsTeamMember_DoesNotUpdateVoteOptions()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
         string facilitator = Guid.NewGuid().ToString();
         string teamMember = Guid.NewGuid().ToString();
         IRoomManager sut = mocker.CreateInstance<TRoomManager>();
@@ -594,7 +597,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task AddUserToRoomAsync_WithDifferentCasing_JoinsSameRoom()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string roomId = "TestRoom123";
         string roomIdLowerCase = "testroom123";
@@ -622,7 +625,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task GetNewUserRoleAsync_WithDifferentCasing_ReturnsSameRole()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string roomId = "TestRoom456";
         string roomIdLowerCase = "testroom456";
@@ -658,7 +661,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task RequestResetVotesAsync_WithTeamMember_SetsResetRequest()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         string teamMember = Guid.NewGuid().ToString();
@@ -680,7 +683,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task RequestResetVotesAsync_WithFacilitator_SetsResetRequest()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         IRoomManager sut = mocker.CreateInstance<TRoomManager>();
@@ -698,7 +701,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task CancelResetVotesAsync_WithFacilitator_CancelsResetRequest()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         string teamMember = Guid.NewGuid().ToString();
@@ -720,7 +723,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task CancelResetVotesAsync_WithTeamMember_DoesNotCancelResetRequest()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         string teamMember1 = Guid.NewGuid().ToString();
@@ -744,7 +747,7 @@ public abstract class RoomManagerTests<TRoomManager>
     public async Task ResetVotesAsync_WithFacilitator_ClearsResetRequest()
     {
         AutoMocker mocker = new();
-        mocker.WithApplicationInsights();
+        UseTestTelemetry(mocker);
 
         string facilitator = Guid.NewGuid().ToString();
         string teamMember = Guid.NewGuid().ToString();

--- a/Tests/PointerStar.Server.Tests/WebApplicationFactory.cs
+++ b/Tests/PointerStar.Server.Tests/WebApplicationFactory.cs
@@ -16,13 +16,16 @@ public class WebApplicationFactory : WebApplicationFactory<Program>
     {
         base.ConfigureWebHost(builder);
 
+        // Ensure the Development environment is used so Program.cs skips
+        // AddApplicationInsightsTelemetry() and its shutdown-blocking OTel exporter.
+        builder.UseEnvironment("Development");
+
         builder.ConfigureServices(services =>
         {
             foreach(var service in AdditionalServices)
             {
                 services.Add(service);
             }
-            // Add any required services to the services container.
         });
     }
 }


### PR DESCRIPTION
## Why
Dependabot updates were not consistently grouped across ecosystems. This creates unnecessary PR noise and makes dependency maintenance harder to review.

## What changed
This updates `.github/dependabot.yml` so each ecosystem opens a single grouped PR:
- **NuGet**: adds a `groups.nuget` rule matching `*`
- **GitHub Actions**: keeps a single `groups.github-actions` rule matching `*`
- **npm**: adds an npm update entry for `PointerStar/ClientApp` with a `groups.npm` rule matching `*`

## Notes
This change only adjusts Dependabot PR grouping behavior; it does not change runtime code or dependency versions.