### PR TITLE
Fix automerge job failing on non-Dependabot PRs

### DIFF
--- a/.github/workflows/main_pointerstar.yml
+++ b/.github/workflows/main_pointerstar.yml
@@ -91,7 +91,7 @@ jobs:
           path: ${{env.DOTNET_ROOT}}/publish
 
   automerge:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
     needs: build
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main_pointerstar.yml
+++ b/.github/workflows/main_pointerstar.yml
@@ -116,6 +116,20 @@ jobs:
         with:
           name: app
 
+      - name: Configure app settings
+        uses: azure/appservice-settings@v1
+        with:
+          app-name: 'pointerstar'
+          publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE }}
+          app-settings-json: |
+            [
+              {
+                "name": "GIPHY_API_KEY",
+                "value": "${{ secrets.GIPHY_API_KEY }}",
+                "slotSetting": false
+              }
+            ]
+
       - name: Deploy to Azure Web App
         id: deploy-to-webapp
         uses: azure/webapps-deploy@v3

--- a/.github/workflows/main_pointerstar.yml
+++ b/.github/workflows/main_pointerstar.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Run React app tests
         run: pnpm run test:run
         working-directory: PointerStar/ClientApp
+        timeout-minutes: 5
 
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v5
@@ -52,9 +53,11 @@ jobs:
 
       - name: dotnet test (shared)
         run: dotnet test Tests/PointerStar.Shared.Tests/PointerStar.Shared.Tests.csproj --configuration Release --no-build --collect:"XPlat Code Coverage" --results-directory ./coverage
+        timeout-minutes: 5
 
       - name: dotnet test (server)
         run: dotnet test Tests/PointerStar.Server.Tests/PointerStar.Server.Tests.csproj --configuration Release --no-build --collect:"XPlat Code Coverage" --results-directory ./coverage
+        timeout-minutes: 5
 
       - name: ReportGenerator
         uses: danielpalme/ReportGenerator-GitHub-Action@5.5.10

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="3.1.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Moq.AutoMock" Version="4.0.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />

--- a/PointerStar/AppHost/PointerStar.AppHost.csproj
+++ b/PointerStar/AppHost/PointerStar.AppHost.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <UserSecretsId>0a713fcb-9cdf-42fe-89ea-7f3eb7cd956d</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PointerStar/AppHost/PointerStar.AppHost.csproj
+++ b/PointerStar/AppHost/PointerStar.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.2">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.5">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>

--- a/PointerStar/AppHost/Program.cs
+++ b/PointerStar/AppHost/Program.cs
@@ -5,6 +5,7 @@ var server = builder.AddProject<Projects.PointerStar_Server>("server")
     .WithEnvironment("EnableClientAppBuild", "false");
 
 builder.AddViteApp("frontend", "..\\ClientApp")
+    .WithPnpm()
     .WithReference(server)
     .WithEnvironment("VITE_BACKEND_URL", server.GetEndpoint("https"));
 

--- a/PointerStar/ClientApp/pnpm-workspace.yaml
+++ b/PointerStar/ClientApp/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
 allowBuilds:
-  esbuild: set this to true or false
+  esbuild: true

--- a/PointerStar/ClientApp/pnpm-workspace.yaml
+++ b/PointerStar/ClientApp/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
 allowBuilds:
-  esbuild: true
+  esbuild: set this to true or false

--- a/PointerStar/ClientApp/src/components/GiphyVoteDisplay.tsx
+++ b/PointerStar/ClientApp/src/components/GiphyVoteDisplay.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react'
 import {
-  ImageList,
-  ImageListItem,
-  ImageListItemBar,
-  Paper,
   Box,
-  Typography,
   CircularProgress,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Paper,
+  Typography,
 } from '@mui/material'
 import ErrorIcon from '@mui/icons-material/Error'
 import type { User } from '../types/contracts'
@@ -22,6 +22,7 @@ interface GiphyVoteDisplayProps {
  */
 export const GiphyVoteDisplay: React.FC<GiphyVoteDisplayProps> = ({ users, showVotes }) => {
   const [imageErrors, setImageErrors] = useState<Set<string>>(new Set())
+  const [selectedGif, setSelectedGif] = useState<{ name: string; url: string } | null>(null)
 
   // Filter users who have voted with Giphy IDs
   const votedUsers = users.filter((user) => user.vote && showVotes)
@@ -51,51 +52,115 @@ export const GiphyVoteDisplay: React.FC<GiphyVoteDisplayProps> = ({ users, showV
 
   return (
     <Paper sx={{ padding: 2 }}>
-      <ImageList cols={Math.min(3, Math.max(1, votedUsers.length))} gap={16}>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5 }}>
         {votedUsers.map((user) => {
           const giphyId = user.vote || ''
           const isErrored = imageErrors.has(giphyId)
+          const hasChangedVote = Boolean(user.originalVote && user.originalVote !== user.vote)
           const imageUrl = `https://media.giphy.com/media/${giphyId}/giphy.gif`
 
           return (
-            <ImageListItem key={user.id}>
+            <Box
+              key={user.id}
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                width: 180,
+              }}
+            >
               {isErrored ? (
                 <Box
                   sx={{
-                    width: '100%',
-                    aspectRatio: '1/1',
-                    backgroundColor: '#f5f5f5',
-                    display: 'flex',
                     alignItems: 'center',
-                    justifyContent: 'center',
+                    backgroundColor: '#f5f5f5',
+                    borderRadius: 1,
+                    display: 'flex',
                     flexDirection: 'column',
+                    height: 120,
+                    justifyContent: 'center',
+                    width: '100%',
                   }}
                 >
-                  <ErrorIcon sx={{ fontSize: 48, color: 'error.main', marginBottom: 1 }} />
+                  <ErrorIcon sx={{ fontSize: 32, color: 'error.main', marginBottom: 1 }} />
                   <Typography variant="caption" color="error">
                     Image failed to load
                   </Typography>
                 </Box>
               ) : (
-                <img
-                  src={imageUrl}
-                  alt={`Vote by ${user.name}`}
-                  loading="lazy"
-                  onError={() => handleImageError(giphyId)}
-                  style={{ width: '100%', height: 'auto', minHeight: 200 }}
-                />
+                <Box
+                  component="button"
+                  onClick={() => setSelectedGif({ name: user.name, url: imageUrl })}
+                  sx={{
+                    alignItems: 'center',
+                    appearance: 'none',
+                    backgroundColor: 'transparent',
+                    borderRadius: 1,
+                    border: hasChangedVote ? '2px dashed' : 0,
+                    borderColor: hasChangedVote ? 'error.main' : 'transparent',
+                    color: 'inherit',
+                    cursor: 'pointer',
+                    display: 'flex',
+                    height: 120,
+                    justifyContent: 'center',
+                    overflow: 'hidden',
+                    p: 0,
+                    '&:hover': {
+                      backgroundColor: 'transparent',
+                    },
+                    width: '100%',
+                  }}
+                >
+                  <img
+                    src={imageUrl}
+                    alt={`Vote by ${user.name}`}
+                    loading="lazy"
+                    onError={() => handleImageError(giphyId)}
+                    style={{
+                      borderRadius: 4,
+                      display: 'block',
+                      height: 'auto',
+                      maxHeight: '100%',
+                      maxWidth: '100%',
+                      width: 'auto',
+                    }}
+                  />
+                </Box>
               )}
-              <ImageListItemBar
-                title={user.name}
-                position="bottom"
+              <Typography
+                variant="caption"
                 sx={{
-                  background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0) 100%)',
+                  display: 'block',
+                  lineHeight: 1.3,
+                  mt: 0.75,
                 }}
-              />
-            </ImageListItem>
+              >
+                {user.name}
+              </Typography>
+            </Box>
           )
         })}
-      </ImageList>
+      </Box>
+      <Dialog
+        maxWidth={false}
+        onClose={() => setSelectedGif(null)}
+        open={selectedGif !== null}
+      >
+        {selectedGif ? <DialogTitle>{selectedGif.name}'s vote</DialogTitle> : null}
+        <DialogContent sx={{ alignItems: 'center', display: 'flex', justifyContent: 'center', p: 2 }}>
+          {selectedGif ? (
+            <img
+              alt={`${selectedGif.name} vote`}
+              src={selectedGif.url}
+              style={{
+                height: 'auto',
+                maxHeight: '85vh',
+                maxWidth: '90vw',
+                width: 'auto',
+              }}
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
     </Paper>
   )
 }

--- a/PointerStar/ClientApp/src/components/GiphyVoteDisplay.tsx
+++ b/PointerStar/ClientApp/src/components/GiphyVoteDisplay.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from 'react'
+import {
+  ImageList,
+  ImageListItem,
+  ImageListItemBar,
+  Paper,
+  Box,
+  Typography,
+  CircularProgress,
+} from '@mui/material'
+import ErrorIcon from '@mui/icons-material/Error'
+import { User } from '../types/contracts'
+
+interface GiphyVoteDisplayProps {
+  users: User[]
+  showVotes: boolean
+}
+
+/**
+ * Component for displaying user Giphy votes as a grid of images.
+ * Shows a placeholder if votes are not shown yet.
+ */
+export const GiphyVoteDisplay: React.FC<GiphyVoteDisplayProps> = ({ users, showVotes }) => {
+  const [imageErrors, setImageErrors] = useState<Set<string>>(new Set())
+
+  // Filter users who have voted with Giphy IDs
+  const votedUsers = users.filter((user) => user.vote && showVotes)
+
+  const handleImageError = (giphyId: string) => {
+    setImageErrors((prev) => new Set(prev).add(giphyId))
+  }
+
+  if (!showVotes) {
+    return (
+      <Box sx={{ textAlign: 'center', padding: 4 }}>
+        <CircularProgress />
+        <Typography sx={{ marginTop: 2 }} color="textSecondary">
+          Waiting for all team members to vote...
+        </Typography>
+      </Box>
+    )
+  }
+
+  if (votedUsers.length === 0) {
+    return (
+      <Box sx={{ textAlign: 'center', padding: 4 }}>
+        <Typography color="textSecondary">No votes submitted yet</Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Paper sx={{ padding: 2 }}>
+      <ImageList cols={Math.min(3, Math.max(1, votedUsers.length))} gap={16}>
+        {votedUsers.map((user) => {
+          const giphyId = user.vote || ''
+          const isErrored = imageErrors.has(giphyId)
+          const imageUrl = `https://media.giphy.com/media/${giphyId}/giphy.gif`
+
+          return (
+            <ImageListItem key={user.id}>
+              {isErrored ? (
+                <Box
+                  sx={{
+                    width: '100%',
+                    aspectRatio: '1/1',
+                    backgroundColor: '#f5f5f5',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexDirection: 'column',
+                  }}
+                >
+                  <ErrorIcon sx={{ fontSize: 48, color: 'error.main', marginBottom: 1 }} />
+                  <Typography variant="caption" color="error">
+                    Image failed to load
+                  </Typography>
+                </Box>
+              ) : (
+                <img
+                  src={imageUrl}
+                  alt={`Vote by ${user.name}`}
+                  loading="lazy"
+                  onError={() => handleImageError(giphyId)}
+                  style={{ width: '100%', height: 'auto', minHeight: 200 }}
+                />
+              )}
+              <ImageListItemBar
+                title={user.name}
+                position="bottom"
+                sx={{
+                  background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0) 100%)',
+                }}
+              />
+            </ImageListItem>
+          )
+        })}
+      </ImageList>
+    </Paper>
+  )
+}

--- a/PointerStar/ClientApp/src/components/GiphyVoteDisplay.tsx
+++ b/PointerStar/ClientApp/src/components/GiphyVoteDisplay.tsx
@@ -9,7 +9,7 @@ import {
   CircularProgress,
 } from '@mui/material'
 import ErrorIcon from '@mui/icons-material/Error'
-import { User } from '../types/contracts'
+import type { User } from '../types/contracts'
 
 interface GiphyVoteDisplayProps {
   users: User[]

--- a/PointerStar/ClientApp/src/components/GiphyVotingPanel.tsx
+++ b/PointerStar/ClientApp/src/components/GiphyVotingPanel.tsx
@@ -4,7 +4,6 @@ import {
   TextField,
   CircularProgress,
   Alert,
-  Grid2 as Grid,
   Paper,
   Typography,
   ImageList,
@@ -12,7 +11,7 @@ import {
   ImageListItemBar,
 } from '@mui/material'
 import SearchIcon from '@mui/icons-material/Search'
-import { GiphyItem } from '../types/contracts'
+import type { GiphyItem } from '../types/contracts'
 import { searchGiphy } from '../services/giphyApi'
 
 interface GiphyVotingPanelProps {
@@ -80,8 +79,10 @@ export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({ onVoteSubmit
           value={searchQuery}
           onChange={handleSearchChange}
           disabled={disabled || loading}
-          InputProps={{
-            startAdornment: <SearchIcon sx={{ marginRight: 1, color: 'action.active' }} />,
+          slotProps={{
+            input: {
+              startAdornment: <SearchIcon sx={{ marginRight: 1, color: 'action.active' }} />,
+            },
           }}
         />
       </Box>

--- a/PointerStar/ClientApp/src/components/GiphyVotingPanel.tsx
+++ b/PointerStar/ClientApp/src/components/GiphyVotingPanel.tsx
@@ -1,34 +1,40 @@
-import React, { useState, useCallback } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import {
-  Box,
-  TextField,
-  CircularProgress,
   Alert,
-  Paper,
-  Typography,
+  Box,
+  Button,
+  CircularProgress,
+  IconButton,
   ImageList,
   ImageListItem,
   ImageListItemBar,
+  Paper,
+  TextField,
+  Typography,
 } from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
 import SearchIcon from '@mui/icons-material/Search'
 import type { GiphyItem } from '../types/contracts'
 import { searchGiphy } from '../services/giphyApi'
 
 interface GiphyVotingPanelProps {
+  currentVote?: string | null
   onVoteSubmit: (giphyId: string) => void
-  disabled?: boolean
 }
 
 /**
  * Component for searching and selecting Giphy images as votes.
  * Displays search results as a grid of clickable images.
+ * Searches are debounced to avoid API calls on every keystroke.
  */
-export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({ onVoteSubmit, disabled }) => {
+export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({ currentVote, onVoteSubmit }) => {
   const [searchQuery, setSearchQuery] = useState('')
   const [results, setResults] = useState<GiphyItem[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [isSearchExpanded, setIsSearchExpanded] = useState(!currentVote)
+  const requestIdRef = useRef(0)
 
   const handleSearch = useCallback(
     async (query: string) => {
@@ -42,7 +48,12 @@ export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({ onVoteSubmit
       setError(null)
 
       try {
+        const requestId = ++requestIdRef.current
         const response = await searchGiphy(query)
+        if (requestId !== requestIdRef.current) {
+          return
+        }
+
         setResults(response.data || [])
 
         if (response.data?.length === 0) {
@@ -59,87 +70,148 @@ export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({ onVoteSubmit
     []
   )
 
-  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value
-    setSearchQuery(value)
-    handleSearch(value)
-  }
+  const clearSearch = useCallback(() => {
+    requestIdRef.current += 1
+    setSearchQuery('')
+    setResults([])
+    setError(null)
+    setLoading(false)
+  }, [])
+
+  useEffect(() => {
+    if (!isSearchExpanded) {
+      return
+    }
+
+    const timeout = setTimeout(() => {
+      void handleSearch(searchQuery)
+    }, 1000)
+
+    return () => {
+      clearTimeout(timeout)
+    }
+  }, [handleSearch, isSearchExpanded, searchQuery])
+
+  useEffect(() => {
+    if (currentVote) {
+      setSelectedId(currentVote)
+      setIsSearchExpanded(false)
+      return
+    }
+
+    setSelectedId(null)
+    setIsSearchExpanded(true)
+    clearSearch()
+  }, [clearSearch, currentVote])
 
   const handleSelectGif = (giphyId: string) => {
     setSelectedId(giphyId)
+    setIsSearchExpanded(false)
     onVoteSubmit(giphyId)
   }
 
   return (
-    <Box sx={{ padding: 2 }}>
-      <Box sx={{ marginBottom: 2 }}>
-        <TextField
-          fullWidth
-          placeholder="Search for a GIF..."
-          value={searchQuery}
-          onChange={handleSearchChange}
-          disabled={disabled || loading}
-          slotProps={{
-            input: {
-              startAdornment: <SearchIcon sx={{ marginRight: 1, color: 'action.active' }} />,
-            },
-          }}
-        />
-      </Box>
-
-      {error && (
-        <Alert severity="error" sx={{ marginBottom: 2 }}>
-          {error}
+    <Box>
+      {!isSearchExpanded ? (
+        <Alert
+          action={
+            <Button onClick={() => setIsSearchExpanded(true)} size="small">
+              Change GIF
+            </Button>
+          }
+          severity="success"
+          sx={{ marginBottom: 2 }}
+        >
+          Vote submitted
         </Alert>
-      )}
+      ) : (
+        <>
+          <Box sx={{ marginBottom: 2 }}>
+            <TextField
+              autoFocus
+              fullWidth
+              placeholder="Search for a GIF..."
+              value={searchQuery}
+              onChange={(e) => {
+                setSearchQuery(e.target.value)
+                setError(null)
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                  event.preventDefault()
+                  clearSearch()
+                }
+              }}
+              slotProps={{
+                input: {
+                  startAdornment: <SearchIcon sx={{ marginRight: 1, color: 'action.active' }} />,
+                  endAdornment: searchQuery ? (
+                    <IconButton aria-label="Clear GIF search" edge="end" onClick={clearSearch} size="small">
+                      <CloseIcon fontSize="small" />
+                    </IconButton>
+                  ) : null,
+                },
+              }}
+            />
+          </Box>
 
-      {loading && (
-        <Box sx={{ display: 'flex', justifyContent: 'center', padding: 4 }}>
-          <CircularProgress />
-        </Box>
-      )}
+          {error && (
+            <Alert severity="error" sx={{ marginBottom: 2 }}>
+              {error}
+            </Alert>
+          )}
 
-      {!loading && results.length > 0 && (
-        <Paper sx={{ padding: 1 }}>
-          <ImageList cols={Math.min(3, Math.max(1, results.length))} gap={8}>
-            {results.map((gif) => (
-              <ImageListItem
-                key={gif.id}
-                sx={{
-                  cursor: 'pointer',
-                  opacity: selectedId === gif.id ? 1 : 0.8,
-                  border: selectedId === gif.id ? '3px solid primary.main' : '1px solid #ddd',
-                  transition: 'all 0.2s ease',
-                  '&:hover': {
-                    opacity: 1,
-                    border: '3px solid primary.main',
-                  },
-                }}
-                onClick={() => handleSelectGif(gif.id)}
-              >
-                <img
-                  src={gif.imageUrl}
-                  alt={gif.title}
-                  loading="lazy"
-                  style={{ cursor: 'pointer' }}
-                />
-                <ImageListItemBar
-                  title={gif.title}
-                  position="bottom"
-                  sx={{
-                    background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0) 100%)',
-                  }}
-                />
-              </ImageListItem>
-            ))}
-          </ImageList>
-        </Paper>
-      )}
+          {loading && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', padding: 4 }}>
+              <CircularProgress />
+            </Box>
+          )}
 
-      {!loading && results.length === 0 && searchQuery.trim() && !error && (
-        <Box sx={{ textAlign: 'center', padding: 2 }}>
-          <Typography color="textSecondary">Enter a search term to find GIFs</Typography>
-        </Box>
+          {!loading && results.length > 0 && (
+            <Paper sx={{ padding: 1 }}>
+              <ImageList cols={Math.min(3, Math.max(1, results.length))} gap={8}>
+                {results.map((gif) => (
+                  <ImageListItem
+                    key={gif.id}
+                    sx={{
+                      cursor: 'pointer',
+                      opacity: selectedId === gif.id ? 1 : 0.8,
+                      border: selectedId === gif.id ? '3px solid' : '1px solid',
+                      borderColor: selectedId === gif.id ? 'primary.main' : 'divider',
+                      transition: 'all 0.2s ease',
+                      '&:hover': {
+                        opacity: 1,
+                        border: '3px solid',
+                        borderColor: 'primary.main',
+                      },
+                    }}
+                    onClick={() => handleSelectGif(gif.id)}
+                  >
+                    <img
+                      src={gif.imageUrl}
+                      alt={gif.title}
+                      loading="lazy"
+                      style={{ cursor: 'pointer' }}
+                    />
+                    <ImageListItemBar
+                      title={gif.title}
+                      position="bottom"
+                      sx={{
+                        background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0) 100%)',
+                      }}
+                    />
+                  </ImageListItem>
+                ))}
+              </ImageList>
+            </Paper>
+          )}
+
+          {!loading && results.length === 0 && searchQuery.trim() && !error && (
+            <Box sx={{ textAlign: 'center', padding: 2 }}>
+              <Typography color="textSecondary">No GIFs found. Try a different search.</Typography>
+            </Box>
+          )}
+        </>
       )}
     </Box>
   )

--- a/PointerStar/ClientApp/src/components/GiphyVotingPanel.tsx
+++ b/PointerStar/ClientApp/src/components/GiphyVotingPanel.tsx
@@ -1,0 +1,145 @@
+import React, { useState, useCallback } from 'react'
+import {
+  Box,
+  TextField,
+  CircularProgress,
+  Alert,
+  Grid2 as Grid,
+  Paper,
+  Typography,
+  ImageList,
+  ImageListItem,
+  ImageListItemBar,
+} from '@mui/material'
+import SearchIcon from '@mui/icons-material/Search'
+import { GiphyItem } from '../types/contracts'
+import { searchGiphy } from '../services/giphyApi'
+
+interface GiphyVotingPanelProps {
+  onVoteSubmit: (giphyId: string) => void
+  disabled?: boolean
+}
+
+/**
+ * Component for searching and selecting Giphy images as votes.
+ * Displays search results as a grid of clickable images.
+ */
+export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({ onVoteSubmit, disabled }) => {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [results, setResults] = useState<GiphyItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+
+  const handleSearch = useCallback(
+    async (query: string) => {
+      if (!query.trim()) {
+        setResults([])
+        setError(null)
+        return
+      }
+
+      setLoading(true)
+      setError(null)
+
+      try {
+        const response = await searchGiphy(query)
+        setResults(response.data || [])
+
+        if (response.data?.length === 0) {
+          setError('No GIFs found. Try a different search.')
+        }
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'Search failed'
+        setError(errorMessage)
+        setResults([])
+      } finally {
+        setLoading(false)
+      }
+    },
+    []
+  )
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setSearchQuery(value)
+    handleSearch(value)
+  }
+
+  const handleSelectGif = (giphyId: string) => {
+    setSelectedId(giphyId)
+    onVoteSubmit(giphyId)
+  }
+
+  return (
+    <Box sx={{ padding: 2 }}>
+      <Box sx={{ marginBottom: 2 }}>
+        <TextField
+          fullWidth
+          placeholder="Search for a GIF..."
+          value={searchQuery}
+          onChange={handleSearchChange}
+          disabled={disabled || loading}
+          InputProps={{
+            startAdornment: <SearchIcon sx={{ marginRight: 1, color: 'action.active' }} />,
+          }}
+        />
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ marginBottom: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {loading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', padding: 4 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {!loading && results.length > 0 && (
+        <Paper sx={{ padding: 1 }}>
+          <ImageList cols={Math.min(3, Math.max(1, results.length))} gap={8}>
+            {results.map((gif) => (
+              <ImageListItem
+                key={gif.id}
+                sx={{
+                  cursor: 'pointer',
+                  opacity: selectedId === gif.id ? 1 : 0.8,
+                  border: selectedId === gif.id ? '3px solid primary.main' : '1px solid #ddd',
+                  transition: 'all 0.2s ease',
+                  '&:hover': {
+                    opacity: 1,
+                    border: '3px solid primary.main',
+                  },
+                }}
+                onClick={() => handleSelectGif(gif.id)}
+              >
+                <img
+                  src={gif.imageUrl}
+                  alt={gif.title}
+                  loading="lazy"
+                  style={{ cursor: 'pointer' }}
+                />
+                <ImageListItemBar
+                  title={gif.title}
+                  position="bottom"
+                  sx={{
+                    background: 'linear-gradient(to top, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0) 100%)',
+                  }}
+                />
+              </ImageListItem>
+            ))}
+          </ImageList>
+        </Paper>
+      )}
+
+      {!loading && results.length === 0 && searchQuery.trim() && !error && (
+        <Box sx={{ textAlign: 'center', padding: 2 }}>
+          <Typography color="textSecondary">Enter a search term to find GIFs</Typography>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/PointerStar/ClientApp/src/components/VotingOptionsDialog.tsx
+++ b/PointerStar/ClientApp/src/components/VotingOptionsDialog.tsx
@@ -7,17 +7,12 @@ import {
 } from '@mui/icons-material'
 import {
   Button,
-  ButtonGroup,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   Divider,
-  FormControl,
   IconButton,
-  InputLabel,
-  MenuItem,
-  Select,
   Stack,
   TextField,
   Typography,
@@ -49,7 +44,6 @@ export function VotingOptionsDialog({
 }: VotingOptionsDialogProps) {
   const [voteOptions, setVoteOptions] = useState<string[]>(currentVoteOptions ?? [...defaultVoteOptions])
   const [votingMode, setVotingMode] = useState<VotingMode>(currentVotingMode ?? VotingMode.Standard)
-  const isModeImmutable = currentVotingMode !== undefined
 
   useEffect(() => {
     if (!open) {
@@ -73,45 +67,40 @@ export function VotingOptionsDialog({
   return (
     <Dialog fullWidth maxWidth="md" onClose={onCancel} open={open}>
       <DialogTitle>Configure Voting Options</DialogTitle>
-      <DialogContent>
+      <DialogContent sx={{ pt: 2 }}>
         <Stack spacing={3}>
-          <FormControl fullWidth>
-            <InputLabel>Voting Mode</InputLabel>
-            <Select
-              disabled={isModeImmutable}
-              label="Voting Mode"
-              onChange={(e) => setVotingMode(e.target.value as VotingMode)}
-              value={votingMode}
-            >
-              <MenuItem value={VotingMode.Standard}>Standard (Numbers/Text)</MenuItem>
-              <MenuItem value={VotingMode.Giphy}>Giphy Mode (Images)</MenuItem>
-            </Select>
-          </FormControl>
-
-          {isModeImmutable && (
-            <Typography variant="caption" color="textSecondary">
-              Note: Voting mode cannot be changed after room creation
-            </Typography>
-          )}
+          <Stack spacing={1}>
+            <Typography variant="body2">Select a preset:</Typography>
+            <Stack direction="row" sx={{ flexWrap: 'wrap', gap: 1 }}>
+              {votingPresets.map((preset) => (
+                <Button
+                  key={preset.name}
+                  onClick={() => {
+                    setVotingMode(VotingMode.Standard)
+                    setVoteOptions([...preset.options])
+                  }}
+                  size="small"
+                  variant={
+                    votingMode === VotingMode.Standard && isPresetSelected(voteOptions, preset.options)
+                      ? 'contained'
+                      : 'outlined'
+                  }
+                >
+                  {preset.name}
+                </Button>
+              ))}
+              <Button
+                onClick={() => setVotingMode(VotingMode.Giphy)}
+                size="small"
+                variant={votingMode === VotingMode.Giphy ? 'contained' : 'outlined'}
+              >
+                Giphy Mode
+              </Button>
+            </Stack>
+          </Stack>
 
           {votingMode === VotingMode.Standard ? (
             <>
-              <Stack spacing={1}>
-                <Typography variant="body2">Select a preset:</Typography>
-                <ButtonGroup sx={{ flexWrap: 'wrap', gap: 1 }}>
-                  {votingPresets.map((preset) => (
-                    <Button
-                      key={preset.name}
-                      onClick={() => setVoteOptions([...preset.options])}
-                      size="small"
-                      variant={isPresetSelected(voteOptions, preset.options) ? 'contained' : 'outlined'}
-                    >
-                      {preset.name}
-                    </Button>
-                  ))}
-                </ButtonGroup>
-              </Stack>
-
               <Divider />
 
               <Stack spacing={1}>

--- a/PointerStar/ClientApp/src/components/VotingOptionsDialog.tsx
+++ b/PointerStar/ClientApp/src/components/VotingOptionsDialog.tsx
@@ -13,18 +13,23 @@ import {
   DialogContent,
   DialogTitle,
   Divider,
+  FormControl,
   IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
   Stack,
   TextField,
   Typography,
 } from '@mui/material'
 
-import { defaultVoteOptions, votingPresets } from '../types/contracts'
+import { defaultVoteOptions, votingPresets, VotingMode } from '../types/contracts'
 
 interface VotingOptionsDialogProps {
   currentVoteOptions?: string[]
+  currentVotingMode?: VotingMode
   onCancel: () => void
-  onSave: (voteOptions: string[]) => void
+  onSave: (voteOptions: string[], votingMode?: VotingMode) => void
   open: boolean
 }
 
@@ -37,11 +42,14 @@ function isPresetSelected(currentVoteOptions: string[], preset: readonly string[
 
 export function VotingOptionsDialog({
   currentVoteOptions,
+  currentVotingMode,
   onCancel,
   onSave,
   open,
 }: VotingOptionsDialogProps) {
   const [voteOptions, setVoteOptions] = useState<string[]>(currentVoteOptions ?? [...defaultVoteOptions])
+  const [votingMode, setVotingMode] = useState<VotingMode>(currentVotingMode ?? VotingMode.Standard)
+  const isModeImmutable = currentVotingMode !== undefined
 
   useEffect(() => {
     if (!open) {
@@ -49,11 +57,17 @@ export function VotingOptionsDialog({
     }
 
     setVoteOptions(currentVoteOptions ? [...currentVoteOptions] : [...defaultVoteOptions])
-  }, [currentVoteOptions, open])
+    setVotingMode(currentVotingMode ?? VotingMode.Standard)
+  }, [currentVoteOptions, currentVotingMode, open])
 
   const isValid = useMemo(
-    () => voteOptions.length > 0 && voteOptions.every((option) => option.trim().length > 0),
-    [voteOptions],
+    () => {
+      if (votingMode === VotingMode.Giphy) {
+        return true
+      }
+      return voteOptions.length > 0 && voteOptions.every((option) => option.trim().length > 0)
+    },
+    [voteOptions, votingMode],
   )
 
   return (
@@ -61,101 +75,128 @@ export function VotingOptionsDialog({
       <DialogTitle>Configure Voting Options</DialogTitle>
       <DialogContent>
         <Stack spacing={3}>
-          <Stack spacing={1}>
-            <Typography variant="body2">Select a preset:</Typography>
-            <ButtonGroup sx={{ flexWrap: 'wrap', gap: 1 }}>
-              {votingPresets.map((preset) => (
-                <Button
-                  key={preset.name}
-                  onClick={() => setVoteOptions([...preset.options])}
-                  size="small"
-                  variant={isPresetSelected(voteOptions, preset.options) ? 'contained' : 'outlined'}
-                >
-                  {preset.name}
-                </Button>
-              ))}
-            </ButtonGroup>
-          </Stack>
-
-          <Divider />
-
-          <Stack spacing={1}>
-            <Typography variant="body2">Or customize your options:</Typography>
-            <Stack spacing={1}>
-              {voteOptions.map((option, index) => (
-                <Stack direction="row" key={`${option}-${index}`} spacing={1} sx={{ alignItems: 'center' }}>
-                  <Stack spacing={0}>
-                    <IconButton
-                      disabled={index === 0}
-                      onClick={() =>
-                        setVoteOptions((current) => {
-                          const next = [...current]
-                          ;[next[index - 1], next[index]] = [next[index], next[index - 1]]
-                          return next
-                        })
-                      }
-                      size="small"
-                    >
-                      <ArrowUpwardIcon fontSize="small" />
-                    </IconButton>
-                    <IconButton
-                      disabled={index === voteOptions.length - 1}
-                      onClick={() =>
-                        setVoteOptions((current) => {
-                          const next = [...current]
-                          ;[next[index + 1], next[index]] = [next[index], next[index + 1]]
-                          return next
-                        })
-                      }
-                      size="small"
-                    >
-                      <ArrowDownwardIcon fontSize="small" />
-                    </IconButton>
-                  </Stack>
-                  <TextField
-                    fullWidth
-                    label={`Option ${index + 1}`}
-                    margin="dense"
-                    onChange={(event) =>
-                      setVoteOptions((current) =>
-                        current.map((currentOption, currentIndex) =>
-                          currentIndex === index ? event.target.value : currentOption,
-                        ),
-                      )
-                    }
-                    value={option}
-                    variant="outlined"
-                  />
-                  <IconButton
-                    color="error"
-                    disabled={voteOptions.length <= 1}
-                    onClick={() =>
-                      setVoteOptions((current) => current.filter((_, currentIndex) => currentIndex !== index))
-                    }
-                    size="small"
-                  >
-                    <DeleteIcon fontSize="small" />
-                  </IconButton>
-                </Stack>
-              ))}
-            </Stack>
-            <Button
-              onClick={() => setVoteOptions((current) => [...current, ''])}
-              size="small"
-              startIcon={<AddIcon />}
-              sx={{ alignSelf: 'flex-start' }}
-              variant="outlined"
+          <FormControl fullWidth>
+            <InputLabel>Voting Mode</InputLabel>
+            <Select
+              disabled={isModeImmutable}
+              label="Voting Mode"
+              onChange={(e) => setVotingMode(e.target.value as VotingMode)}
+              value={votingMode}
             >
-              Add Option
-            </Button>
-          </Stack>
+              <MenuItem value={VotingMode.Standard}>Standard (Numbers/Text)</MenuItem>
+              <MenuItem value={VotingMode.Giphy}>Giphy Mode (Images)</MenuItem>
+            </Select>
+          </FormControl>
+
+          {isModeImmutable && (
+            <Typography variant="caption" color="textSecondary">
+              Note: Voting mode cannot be changed after room creation
+            </Typography>
+          )}
+
+          {votingMode === VotingMode.Standard ? (
+            <>
+              <Stack spacing={1}>
+                <Typography variant="body2">Select a preset:</Typography>
+                <ButtonGroup sx={{ flexWrap: 'wrap', gap: 1 }}>
+                  {votingPresets.map((preset) => (
+                    <Button
+                      key={preset.name}
+                      onClick={() => setVoteOptions([...preset.options])}
+                      size="small"
+                      variant={isPresetSelected(voteOptions, preset.options) ? 'contained' : 'outlined'}
+                    >
+                      {preset.name}
+                    </Button>
+                  ))}
+                </ButtonGroup>
+              </Stack>
+
+              <Divider />
+
+              <Stack spacing={1}>
+                <Typography variant="body2">Or customize your options:</Typography>
+                <Stack spacing={1}>
+                  {voteOptions.map((option, index) => (
+                    <Stack direction="row" key={`${option}-${index}`} spacing={1} sx={{ alignItems: 'center' }}>
+                      <Stack spacing={0}>
+                        <IconButton
+                          disabled={index === 0}
+                          onClick={() =>
+                            setVoteOptions((current) => {
+                              const next = [...current]
+                              ;[next[index - 1], next[index]] = [next[index], next[index - 1]]
+                              return next
+                            })
+                          }
+                          size="small"
+                        >
+                          <ArrowUpwardIcon fontSize="small" />
+                        </IconButton>
+                        <IconButton
+                          disabled={index === voteOptions.length - 1}
+                          onClick={() =>
+                            setVoteOptions((current) => {
+                              const next = [...current]
+                              ;[next[index + 1], next[index]] = [next[index], next[index + 1]]
+                              return next
+                            })
+                          }
+                          size="small"
+                        >
+                          <ArrowDownwardIcon fontSize="small" />
+                        </IconButton>
+                      </Stack>
+                      <TextField
+                        fullWidth
+                        label={`Option ${index + 1}`}
+                        margin="dense"
+                        onChange={(event) =>
+                          setVoteOptions((current) =>
+                            current.map((currentOption, currentIndex) =>
+                              currentIndex === index ? event.target.value : currentOption,
+                            ),
+                          )
+                        }
+                        value={option}
+                        variant="outlined"
+                      />
+                      <IconButton
+                        color="error"
+                        disabled={voteOptions.length <= 1}
+                        onClick={() =>
+                          setVoteOptions((current) => current.filter((_, currentIndex) => currentIndex !== index))
+                        }
+                        size="small"
+                      >
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </Stack>
+                  ))}
+                </Stack>
+                <Button
+                  onClick={() => setVoteOptions((current) => [...current, ''])}
+                  size="small"
+                  startIcon={<AddIcon />}
+                  sx={{ alignSelf: 'flex-start' }}
+                  variant="outlined"
+                >
+                  Add Option
+                </Button>
+              </Stack>
+            </>
+          ) : (
+            <Typography variant="body2" color="textSecondary">
+              In Giphy mode, team members will select images from Giphy instead of using preset voting options.
+            </Typography>
+          )}
         </Stack>
       </DialogContent>
       <DialogActions>
         <Button onClick={onCancel}>Cancel</Button>
         <Button
           disabled={!isValid}
-          onClick={() => onSave(voteOptions.map((option) => option.trim()))}
+          onClick={() => onSave(votingMode === VotingMode.Giphy ? [] : voteOptions.map((option) => option.trim()), votingMode)}
           variant="contained"
         >
           Save

--- a/PointerStar/ClientApp/src/pages/RoomPage.tsx
+++ b/PointerStar/ClientApp/src/pages/RoomPage.tsx
@@ -532,19 +532,14 @@ export function RoomPage() {
         {isRole(currentUser, roles.teamMember) ? (
           <>
             {roomState?.votingMode === VotingMode.Giphy ? (
-              <Card>
-                <CardHeader title="Select a GIF" />
-                <CardContent>
-                  <GiphyVotingPanel
-                    disabled={votesShown}
-                    onVoteSubmit={(giphyId) => {
-                      void callHub(async (client) => {
-                        await client.submitVote(giphyId)
-                      })
-                    }}
-                  />
-                </CardContent>
-              </Card>
+              <GiphyVotingPanel
+                currentVote={currentUser?.vote}
+                onVoteSubmit={(giphyId) => {
+                  void callHub(async (client) => {
+                    await client.submitVote(giphyId)
+                  })
+                }}
+              />
             ) : (
               <Box sx={{ display: 'flex', flexWrap: 'wrap' }}>
                 {(roomState?.voteOptions ?? defaultVoteOptions).map((option) => (
@@ -694,23 +689,62 @@ export function RoomPage() {
                     ) : null}
                     {user.name}
                     {votesShown && user.vote ? (
-                      <>
-                        {' - '}
-                        {user.originalVote && user.originalVote !== user.vote ? (
-                          <Box component="span" sx={{ fontStyle: 'italic' }}>
-                            ({user.originalVote}){' '}
-                          </Box>
-                        ) : null}
-                        <Box component="span" sx={{ fontWeight: 700 }}>
-                          {user.vote}
+                      roomState?.votingMode === VotingMode.Giphy ? (
+                        <Box component="span" sx={{ display: 'inline-flex', ml: 0.75, verticalAlign: 'middle' }}>
+                          <img
+                            alt={`${user.name} vote`}
+                            loading="lazy"
+                            src={`https://media.giphy.com/media/${user.vote}/giphy.gif`}
+                            style={{
+                              borderRadius: 4,
+                              height: 24,
+                              objectFit: 'cover',
+                              width: 24,
+                            }}
+                          />
                         </Box>
-                      </>
+                      ) : (
+                        <>
+                          {' - '}
+                          {user.originalVote && user.originalVote !== user.vote ? (
+                            <Box component="span" sx={{ fontStyle: 'italic' }}>
+                              ({user.originalVote}){' '}
+                            </Box>
+                          ) : null}
+                          <Box component="span" sx={{ fontWeight: 700 }}>
+                            {user.vote}
+                          </Box>
+                        </>
+                      )
                     ) : isRole(currentUser, roles.facilitator) || isRole(currentUser, roles.observer) ? (
                       previewVotes ? (
-                        <Box component="span" sx={{ fontStyle: 'italic' }}>
-                          {' '}
-                          - {user.vote || '…'}
-                        </Box>
+                        roomState?.votingMode === VotingMode.Giphy ? (
+                          user.vote ? (
+                            <Box component="span" sx={{ display: 'inline-flex', ml: 0.75, verticalAlign: 'middle' }}>
+                              <img
+                                alt={`${user.name} vote`}
+                                loading="lazy"
+                                src={`https://media.giphy.com/media/${user.vote}/giphy.gif`}
+                                style={{
+                                  borderRadius: 4,
+                                  height: 24,
+                                  objectFit: 'cover',
+                                  width: 24,
+                                }}
+                              />
+                            </Box>
+                          ) : (
+                            <Box component="span" sx={{ fontStyle: 'italic' }}>
+                              {' '}
+                              - …
+                            </Box>
+                          )
+                        ) : (
+                          <Box component="span" sx={{ fontStyle: 'italic' }}>
+                            {' '}
+                            - {user.vote || '…'}
+                          </Box>
+                        )
                       ) : (
                         <Box component="span"> - {user.vote ? '✓' : '…'}</Box>
                       )

--- a/PointerStar/ClientApp/src/pages/RoomPage.tsx
+++ b/PointerStar/ClientApp/src/pages/RoomPage.tsx
@@ -32,6 +32,8 @@ import { QRCodeSVG } from 'qrcode.react'
 
 import { UserDialog } from '../components/UserDialog'
 import { VotingOptionsDialog } from '../components/VotingOptionsDialog'
+import { GiphyVotingPanel } from '../components/GiphyVotingPanel'
+import { GiphyVoteDisplay } from '../components/GiphyVoteDisplay'
 import {
   getStoredName,
   getStoredRoleId,
@@ -54,6 +56,7 @@ import {
   type RoomState,
   type User,
   type UserOptions,
+  VotingMode,
 } from '../types/contracts'
 import { getElapsedTimeLabel } from './roomTime'
 
@@ -527,23 +530,41 @@ export function RoomPage() {
         ) : null}
 
         {isRole(currentUser, roles.teamMember) ? (
-          <Box sx={{ display: 'flex', flexWrap: 'wrap' }}>
-            {(roomState?.voteOptions ?? defaultVoteOptions).map((option) => (
-              <Button
-                color={option === currentUser?.vote ? 'success' : 'primary'}
-                key={option}
-                onClick={() => {
-                  void callHub(async (client) => {
-                    await client.submitVote(option)
-                  })
-                }}
-                sx={{ height: 70, m: 0.5, minWidth: 70, px: 2.5 }}
-                variant="contained"
-              >
-                {option}
-              </Button>
-            ))}
-          </Box>
+          <>
+            {roomState?.votingMode === VotingMode.Giphy ? (
+              <Card>
+                <CardHeader title="Select a GIF" />
+                <CardContent>
+                  <GiphyVotingPanel
+                    disabled={votesShown}
+                    onVoteSubmit={(giphyId) => {
+                      void callHub(async (client) => {
+                        await client.submitVote(giphyId)
+                      })
+                    }}
+                  />
+                </CardContent>
+              </Card>
+            ) : (
+              <Box sx={{ display: 'flex', flexWrap: 'wrap' }}>
+                {(roomState?.voteOptions ?? defaultVoteOptions).map((option) => (
+                  <Button
+                    color={option === currentUser?.vote ? 'success' : 'primary'}
+                    key={option}
+                    onClick={() => {
+                      void callHub(async (client) => {
+                        await client.submitVote(option)
+                      })
+                    }}
+                    sx={{ height: 70, m: 0.5, minWidth: 70, px: 2.5 }}
+                    variant="contained"
+                  >
+                    {option}
+                  </Button>
+                ))}
+              </Box>
+            )}
+          </>
         ) : null}
 
         {isRole(currentUser, roles.facilitator) ? (
@@ -609,32 +630,43 @@ export function RoomPage() {
         ) : null}
 
         {votesShown && roomState ? (
-          <Card>
-            <CardHeader title="Results" />
-            <CardContent>
-              <Stack spacing={1}>
-                {groupedVotes.map((entry) => {
-                  const percentage = teamMembers.length === 0 ? 0 : entry.count / teamMembers.length
-                  const isHighestCount = entry.count === maxVoteCount
-                  const label = `${entry.vote.trim() ? entry.vote : '…'} - ${entry.count} Vote${entry.count === 1 ? '' : 's'} (${percentage.toLocaleString(undefined, { style: 'percent', maximumFractionDigits: 0 })})`
+          <>
+            {roomState.votingMode === VotingMode.Giphy ? (
+              <Card>
+                <CardHeader title="Votes" />
+                <CardContent>
+                  <GiphyVoteDisplay users={teamMembers} showVotes={votesShown} />
+                </CardContent>
+              </Card>
+            ) : (
+              <Card>
+                <CardHeader title="Results" />
+                <CardContent>
+                  <Stack spacing={1}>
+                    {groupedVotes.map((entry) => {
+                      const percentage = teamMembers.length === 0 ? 0 : entry.count / teamMembers.length
+                      const isHighestCount = entry.count === maxVoteCount
+                      const label = `${entry.vote.trim() ? entry.vote : '…'} - ${entry.count} Vote${entry.count === 1 ? '' : 's'} (${percentage.toLocaleString(undefined, { style: 'percent', maximumFractionDigits: 0 })})`
 
-                  return (
-                    <Box key={entry.vote || 'blank'}>
-                      <Typography variant={isHighestCount ? 'body1' : 'body2'}>{label}</Typography>
-                      <Box
-                        sx={(theme) => ({
-                          backgroundColor: isHighestCount ? theme.palette.primary.dark : theme.palette.primary.light,
-                          height: 10,
-                          mt: 0.5,
-                          width: `${percentage * 100}%`,
-                        })}
-                      />
-                    </Box>
-                  )
-                })}
-              </Stack>
-            </CardContent>
-          </Card>
+                      return (
+                        <Box key={entry.vote || 'blank'}>
+                          <Typography variant={isHighestCount ? 'body1' : 'body2'}>{label}</Typography>
+                          <Box
+                            sx={(theme) => ({
+                              backgroundColor: isHighestCount ? theme.palette.primary.dark : theme.palette.primary.light,
+                              height: 10,
+                              mt: 0.5,
+                              width: `${percentage * 100}%`,
+                            })}
+                          />
+                        </Box>
+                      )
+                    })}
+                  </Stack>
+                </CardContent>
+              </Card>
+            )}
+          </>
         ) : null}
 
         <Card>
@@ -737,11 +769,16 @@ export function RoomPage() {
 
       <VotingOptionsDialog
         currentVoteOptions={roomState?.voteOptions}
+        currentVotingMode={roomState?.votingMode}
         onCancel={() => setShowVotingOptionsDialog(false)}
-        onSave={(nextVoteOptions) => {
+        onSave={(nextVoteOptions, nextVotingMode) => {
           setShowVotingOptionsDialog(false)
           setStoredVoteOptions(nextVoteOptions)
-          void requestRoomUpdate({ voteOptions: nextVoteOptions })
+          const update: RoomOptions = { voteOptions: nextVoteOptions }
+          if (nextVotingMode !== undefined) {
+            update.votingMode = nextVotingMode
+          }
+          void requestRoomUpdate(update)
         }}
         open={showVotingOptionsDialog}
       />

--- a/PointerStar/ClientApp/src/services/giphyApi.ts
+++ b/PointerStar/ClientApp/src/services/giphyApi.ts
@@ -1,4 +1,4 @@
-import { GiphySearchResponse } from '../types/contracts'
+import type { GiphySearchResponse } from '../types/contracts'
 
 /**
  * Service for interacting with the Giphy API endpoint.

--- a/PointerStar/ClientApp/src/services/giphyApi.ts
+++ b/PointerStar/ClientApp/src/services/giphyApi.ts
@@ -1,0 +1,34 @@
+import { GiphySearchResponse } from '../types/contracts'
+
+/**
+ * Service for interacting with the Giphy API endpoint.
+ * Handles searching for Giphy images and error handling.
+ */
+
+export async function searchGiphy(query: string): Promise<GiphySearchResponse> {
+  try {
+    const response = await fetch(`/api/giphy/search?query=${encodeURIComponent(query)}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+
+    if (!response.ok) {
+      if (response.status === 429) {
+        throw new Error('Rate limit exceeded. Please wait before searching again.')
+      }
+      throw new Error(`API error: ${response.status} ${response.statusText}`)
+    }
+
+    const data: GiphySearchResponse = await response.json()
+    return data
+  } catch (error) {
+    console.error('Giphy search failed:', error)
+    // Return empty results on failure for graceful degradation
+    return {
+      data: [],
+      pagination: null,
+    }
+  }
+}

--- a/PointerStar/ClientApp/src/types/contracts.ts
+++ b/PointerStar/ClientApp/src/types/contracts.ts
@@ -3,6 +3,11 @@ export interface Role {
   name: string
 }
 
+export enum VotingMode {
+  Standard = 0,
+  Giphy = 1,
+}
+
 export interface User {
   id: string
   name: string
@@ -20,12 +25,14 @@ export interface RoomState {
   voteOptions: string[]
   voteStartTime?: string | null
   votesShown: boolean
+  votingMode?: VotingMode
 }
 
 export interface RoomOptions {
   autoShowVotes?: boolean
   voteOptions?: string[]
   votesShown?: boolean
+  votingMode?: VotingMode
 }
 
 export interface UserOptions {
@@ -112,3 +119,21 @@ export const votingPresets = [
 
 export const defaultVoteOptions = [...votingPresets[0].options]
 export const userNameMaxLength = 40
+
+// Giphy API response types
+export interface GiphyItem {
+  id: string
+  title: string
+  imageUrl: string
+}
+
+export interface PaginationInfo {
+  count: number
+  offset: number
+  totalCount: number
+}
+
+export interface GiphySearchResponse {
+  data: GiphyItem[]
+  pagination?: PaginationInfo | null
+}

--- a/PointerStar/ClientApp/src/types/contracts.ts
+++ b/PointerStar/ClientApp/src/types/contracts.ts
@@ -3,10 +3,12 @@ export interface Role {
   name: string
 }
 
-export enum VotingMode {
-  Standard = 0,
-  Giphy = 1,
-}
+export const VotingMode = {
+  Standard: 0,
+  Giphy: 1,
+} as const
+
+export type VotingMode = typeof VotingMode[keyof typeof VotingMode]
 
 export interface User {
   id: string

--- a/PointerStar/Server/Controllers/GiphyController.cs
+++ b/PointerStar/Server/Controllers/GiphyController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
 using System.Collections.Concurrent;
 using System.Net.Http;
 using System.Text.Json;
@@ -12,21 +13,21 @@ namespace PointerStar.Server.Controllers;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-public class GiphyController(IHttpClientFactory httpClientFactory, IMemoryCache memoryCache) : ControllerBase
+public class GiphyController(IHttpClientFactory httpClientFactory, IMemoryCache memoryCache, IConfiguration configuration) : ControllerBase
 {
-    private const string GiphyApiKey = "YOUR_GIPHY_API_KEY"; // TODO: Use user secrets in production
     private const string GiphyApiBaseUrl = "https://api.giphy.com/v1";
     private const int RateLimitPerMinute = 10;
-    private const int CacheDurationMinutes = 5;
+    private const int CacheDurationMinutes = 30;
 
     private static readonly ConcurrentDictionary<string, DateTime[]> UserSearchTimestamps = new();
     private IHttpClientFactory HttpClientFactory { get; } = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
     private IMemoryCache MemoryCache { get; } = memoryCache ?? throw new ArgumentNullException(nameof(memoryCache));
+    private IConfiguration Configuration { get; } = configuration ?? throw new ArgumentNullException(nameof(configuration));
 
     /// <summary>
     /// Search Giphy for images matching the query.
     /// Rate-limited to 10 searches per user per minute.
-    /// Results cached for 5 minutes.
+    /// Results cached for 30 minutes.
     /// </summary>
     [HttpGet("Search")]
     public async Task<ActionResult<GiphySearchResponse>> Search([FromQuery] string query)
@@ -50,10 +51,16 @@ public class GiphyController(IHttpClientFactory httpClientFactory, IMemoryCache 
             return cachedResult!;
         }
 
+        string? giphyApiKey = Configuration["Giphy:ApiKey"] ?? Configuration["GIPHY_API_KEY"];
+        if (string.IsNullOrWhiteSpace(giphyApiKey))
+        {
+            return Ok(new GiphySearchResponse { Data = [], Pagination = null });
+        }
+
         try
         {
             using var httpClient = HttpClientFactory.CreateClient();
-            string url = $"{GiphyApiBaseUrl}/gifs/search?api_key={GiphyApiKey}&q={Uri.EscapeDataString(query)}&limit=20&offset=0&rating=g&lang=en";
+            string url = $"{GiphyApiBaseUrl}/gifs/search?api_key={giphyApiKey}&q={Uri.EscapeDataString(query)}&limit=21&offset=0&rating=g&lang=en";
 
             using var response = await httpClient.GetAsync(url);
             if (!response.IsSuccessStatusCode)
@@ -71,7 +78,7 @@ public class GiphyController(IHttpClientFactory httpClientFactory, IMemoryCache 
             var result = new GiphySearchResponse
             {
                 Data = ExtractGiphyIds(root),
-                Pagination = new PaginationInfo { Count = 20 }
+                Pagination = new PaginationInfo { Count = 21 }
             };
 
             // Cache the result

--- a/PointerStar/Server/Controllers/GiphyController.cs
+++ b/PointerStar/Server/Controllers/GiphyController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using System.Collections.Concurrent;
 using System.Net.Http;
+using System.Text.Json;
 
 namespace PointerStar.Server.Controllers;
 
@@ -63,12 +64,13 @@ public class GiphyController(IHttpClientFactory httpClientFactory, IMemoryCache 
             }
 
             var content = await response.Content.ReadAsStringAsync();
-            var giphyResponse = System.Text.Json.JsonSerializer.Deserialize<dynamic>(content);
+            using var jsonDoc = JsonDocument.Parse(content);
+            var root = jsonDoc.RootElement;
 
             // Parse the response and extract GIFs
             var result = new GiphySearchResponse
             {
-                Data = ExtractGiphyIds(giphyResponse),
+                Data = ExtractGiphyIds(root),
                 Pagination = new PaginationInfo { Count = 20 }
             };
 
@@ -81,7 +83,7 @@ public class GiphyController(IHttpClientFactory httpClientFactory, IMemoryCache 
 
             return Ok(result);
         }
-        catch (Exception ex)
+        catch
         {
             // Log the exception and return empty results
             // In production, this should be logged properly
@@ -122,32 +124,57 @@ public class GiphyController(IHttpClientFactory httpClientFactory, IMemoryCache 
     /// <summary>
     /// Extracts Giphy IDs from the API response.
     /// </summary>
-    private static List<GiphyItem> ExtractGiphyIds(dynamic? giphyResponse)
+    private static List<GiphyItem> ExtractGiphyIds(JsonElement root)
     {
         var items = new List<GiphyItem>();
 
         try
         {
-            if (giphyResponse?.data is System.Collections.IEnumerable data)
+            if (root.TryGetProperty("data", out var dataArray))
             {
-                foreach (var gif in data)
+                foreach (var gif in dataArray.EnumerateArray())
                 {
-                    if (gif is not null)
-                    {
-                        // Try to access the ID safely
-                        string? id = gif.id?.ToString();
-                        string? title = gif.title?.ToString() ?? gif.slug?.ToString() ?? "Untitled";
-                        string? imageUrl = gif.images?.fixed_height?.url?.ToString();
+                    string? id = null;
+                    string? title = null;
+                    string? imageUrl = null;
 
-                        if (!string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(imageUrl))
+                    // Extract ID
+                    if (gif.TryGetProperty("id", out var idElement))
+                    {
+                        id = idElement.GetString();
+                    }
+
+                    // Extract title (prefer 'title', fallback to 'slug')
+                    if (gif.TryGetProperty("title", out var titleElement) && titleElement.ValueKind != JsonValueKind.Null)
+                    {
+                        title = titleElement.GetString();
+                    }
+                    else if (gif.TryGetProperty("slug", out var slugElement) && slugElement.ValueKind != JsonValueKind.Null)
+                    {
+                        title = slugElement.GetString();
+                    }
+                    
+                    if (string.IsNullOrEmpty(title))
+                    {
+                        title = "Untitled";
+                    }
+
+                    // Extract image URL from images.fixed_height.url
+                    if (gif.TryGetProperty("images", out var imagesElement) &&
+                        imagesElement.TryGetProperty("fixed_height", out var fixedHeightElement) &&
+                        fixedHeightElement.TryGetProperty("url", out var urlElement))
+                    {
+                        imageUrl = urlElement.GetString();
+                    }
+
+                    if (!string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(imageUrl))
+                    {
+                        items.Add(new GiphyItem
                         {
-                            items.Add(new GiphyItem
-                            {
-                                Id = id,
-                                Title = title,
-                                ImageUrl = imageUrl
-                            });
-                        }
+                            Id = id,
+                            Title = title ?? "Untitled",
+                            ImageUrl = imageUrl
+                        });
                     }
                 }
             }

--- a/PointerStar/Server/Controllers/GiphyController.cs
+++ b/PointerStar/Server/Controllers/GiphyController.cs
@@ -1,0 +1,191 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using System.Collections.Concurrent;
+using System.Net.Http;
+
+namespace PointerStar.Server.Controllers;
+
+/// <summary>
+/// Controller for Giphy-related API operations.
+/// Handles searching Giphy with rate-limiting and caching.
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+public class GiphyController(IHttpClientFactory httpClientFactory, IMemoryCache memoryCache) : ControllerBase
+{
+    private const string GiphyApiKey = "YOUR_GIPHY_API_KEY"; // TODO: Use user secrets in production
+    private const string GiphyApiBaseUrl = "https://api.giphy.com/v1";
+    private const int RateLimitPerMinute = 10;
+    private const int CacheDurationMinutes = 5;
+
+    private static readonly ConcurrentDictionary<string, DateTime[]> UserSearchTimestamps = new();
+    private IHttpClientFactory HttpClientFactory { get; } = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+    private IMemoryCache MemoryCache { get; } = memoryCache ?? throw new ArgumentNullException(nameof(memoryCache));
+
+    /// <summary>
+    /// Search Giphy for images matching the query.
+    /// Rate-limited to 10 searches per user per minute.
+    /// Results cached for 5 minutes.
+    /// </summary>
+    [HttpGet("Search")]
+    public async Task<ActionResult<GiphySearchResponse>> Search([FromQuery] string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return BadRequest(new { error = "Query parameter is required" });
+        }
+
+        // Rate limiting: check if user has exceeded the limit
+        string userId = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        if (!IsWithinRateLimit(userId))
+        {
+            return StatusCode(429, new { error = "Rate limit exceeded. Maximum 10 searches per minute." });
+        }
+
+        // Check cache first
+        string cacheKey = $"giphy_search_{query.ToLower()}";
+        if (MemoryCache.TryGetValue(cacheKey, out GiphySearchResponse? cachedResult))
+        {
+            return cachedResult!;
+        }
+
+        try
+        {
+            using var httpClient = HttpClientFactory.CreateClient();
+            string url = $"{GiphyApiBaseUrl}/gifs/search?api_key={GiphyApiKey}&q={Uri.EscapeDataString(query)}&limit=20&offset=0&rating=g&lang=en";
+
+            using var response = await httpClient.GetAsync(url);
+            if (!response.IsSuccessStatusCode)
+            {
+                // Graceful failure: return empty results if Giphy API is unavailable
+                var emptyResult = new GiphySearchResponse { Data = [], Pagination = null };
+                return Ok(emptyResult);
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            var giphyResponse = System.Text.Json.JsonSerializer.Deserialize<dynamic>(content);
+
+            // Parse the response and extract GIFs
+            var result = new GiphySearchResponse
+            {
+                Data = ExtractGiphyIds(giphyResponse),
+                Pagination = new PaginationInfo { Count = 20 }
+            };
+
+            // Cache the result
+            var cacheOptions = new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(CacheDurationMinutes)
+            };
+            MemoryCache.Set(cacheKey, result, cacheOptions);
+
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            // Log the exception and return empty results
+            // In production, this should be logged properly
+            var emptyResult = new GiphySearchResponse { Data = [], Pagination = null };
+            return Ok(emptyResult);
+        }
+    }
+
+    /// <summary>
+    /// Checks if the user is within the rate limit.
+    /// Maintains a sliding window of timestamps for each user.
+    /// </summary>
+    private static bool IsWithinRateLimit(string userId)
+    {
+        var now = DateTime.UtcNow;
+        var timestamps = UserSearchTimestamps.GetOrAdd(userId, _ => []);
+
+        // Remove timestamps older than 1 minute
+        var recentTimestamps = timestamps
+            .Where(ts => (now - ts).TotalSeconds < 60)
+            .ToArray();
+
+        // Update the stored timestamps
+        UserSearchTimestamps[userId] = recentTimestamps;
+
+        if (recentTimestamps.Length >= RateLimitPerMinute)
+        {
+            return false;
+        }
+
+        // Record this search
+        var newTimestamps = recentTimestamps.Append(now).ToArray();
+        UserSearchTimestamps[userId] = newTimestamps;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Extracts Giphy IDs from the API response.
+    /// </summary>
+    private static List<GiphyItem> ExtractGiphyIds(dynamic? giphyResponse)
+    {
+        var items = new List<GiphyItem>();
+
+        try
+        {
+            if (giphyResponse?.data is System.Collections.IEnumerable data)
+            {
+                foreach (var gif in data)
+                {
+                    if (gif is not null)
+                    {
+                        // Try to access the ID safely
+                        string? id = gif.id?.ToString();
+                        string? title = gif.title?.ToString() ?? gif.slug?.ToString() ?? "Untitled";
+                        string? imageUrl = gif.images?.fixed_height?.url?.ToString();
+
+                        if (!string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(imageUrl))
+                        {
+                            items.Add(new GiphyItem
+                            {
+                                Id = id,
+                                Title = title,
+                                ImageUrl = imageUrl
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // If parsing fails, return empty list
+        }
+
+        return items;
+    }
+}
+
+/// <summary>
+/// Response model for Giphy search results.
+/// </summary>
+public class GiphySearchResponse
+{
+    public List<GiphyItem> Data { get; set; } = [];
+    public PaginationInfo? Pagination { get; set; }
+}
+
+/// <summary>
+/// Represents a single Giphy GIF result.
+/// </summary>
+public class GiphyItem
+{
+    public string Id { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string ImageUrl { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Pagination information for search results.
+/// </summary>
+public class PaginationInfo
+{
+    public int Count { get; set; }
+    public int Offset { get; set; }
+    public int TotalCount { get; set; }
+}

--- a/PointerStar/Server/PointerStar.Server.csproj
+++ b/PointerStar/Server/PointerStar.Server.csproj
@@ -5,6 +5,7 @@
     <SpaRoot>..\ClientApp\</SpaRoot>
     <SpaDist>$(SpaRoot)dist\</SpaDist>
     <EnableClientAppBuild Condition="'$(EnableClientAppBuild)' == ''">true</EnableClientAppBuild>
+    <UserSecretsId>c5e9061f-fc62-4169-a348-2523a3570224</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PointerStar/Server/Program.cs
+++ b/PointerStar/Server/Program.cs
@@ -19,6 +19,8 @@ else
 
 builder.Services.AddControllers();
 builder.Services.AddRazorPages();
+builder.Services.AddHttpClient();
+builder.Services.AddMemoryCache();
 
 //TODO: Make these configurable settings
 builder.Services.AddSignalR(hubOptions => hubOptions.EnableDetailedErrors = true)

--- a/PointerStar/Server/Program.cs
+++ b/PointerStar/Server/Program.cs
@@ -28,6 +28,7 @@ else
     });
 }
 
+builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddControllers();
 builder.Services.AddRazorPages();
 builder.Services.AddHttpClient();

--- a/PointerStar/Server/Program.cs
+++ b/PointerStar/Server/Program.cs
@@ -8,13 +8,24 @@ using PointerStar.Server.Room;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-if (builder.Environment.IsDevelopment())
+string? appInsightsConnectionString = builder.Configuration["ApplicationInsights:ConnectionString"]
+    ?? builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
+
+if (string.IsNullOrWhiteSpace(appInsightsConnectionString))
 {
-    builder.Services.AddSingleton<TelemetryClient>(x => new(TelemetryConfiguration.CreateDefault()));
+    builder.Services.AddSingleton(_ =>
+    {
+        var telemetryConfiguration = TelemetryConfiguration.CreateDefault();
+        telemetryConfiguration.DisableTelemetry = true;
+        return new TelemetryClient(telemetryConfiguration);
+    });
 }
 else
 {
-    builder.Services.AddApplicationInsightsTelemetry();
+    builder.Services.AddApplicationInsightsTelemetry(options =>
+    {
+        options.ConnectionString = appInsightsConnectionString;
+    });
 }
 
 builder.Services.AddControllers();

--- a/PointerStar/Server/Room/InMemoryRoomManager.cs
+++ b/PointerStar/Server/Room/InMemoryRoomManager.cs
@@ -57,7 +57,8 @@ public class InMemoryRoomManager : IRoomManager
             {
                 TelemetryClient?.TrackEvent("RoomCreated", new Dictionary<string, string>
                 {
-                    { "RoomId", rv.RoomId }
+                    { "RoomId", rv.RoomId },
+                    { "VotingMode", rv.VotingMode.ToString() }
                 });
             }
 
@@ -179,6 +180,13 @@ public class InMemoryRoomManager : IRoomManager
                 {
                     room = room with { VoteOptions = voteOptions };
                 }
+
+                // Prevent voting mode changes mid-session (mode is immutable after room creation)
+                if (roomOptions.VotingMode.HasValue && roomOptions.VotingMode != room.VotingMode)
+                {
+                    Logger.LogWarning("Attempt to change voting mode mid-session for room {RoomId} (not allowed)", room.RoomId);
+                }
+
                 return room;
             }
             return room;
@@ -216,10 +224,12 @@ public class InMemoryRoomManager : IRoomManager
     {
         return WithConnection(connectionId, (room, currentUser) =>
         {
-            if (!room.VoteOptions.Contains(vote))
+            // Validate vote based on voting mode
+            if (!IsValidVote(vote, room.VotingMode, room.VoteOptions))
             {
                 return room;
             }
+
             var roomState = room with
             {
                 Users = [..room.Users.Select(u => u.Id == currentUser.Id ? u with
@@ -435,6 +445,36 @@ public class InMemoryRoomManager : IRoomManager
             }
         }
         return false;
+    }
+
+    /// <summary>
+    /// Validates a vote based on the current voting mode.
+    /// </summary>
+    private static bool IsValidVote(string vote, VotingMode votingMode, string[] voteOptions)
+    {
+        return votingMode switch
+        {
+            VotingMode.Standard => voteOptions.Contains(vote),
+            VotingMode.Giphy => IsValidGiphyId(vote),
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Validates that a vote is a properly formatted Giphy ID.
+    /// Giphy IDs are alphanumeric strings, typically 16-20 characters.
+    /// Pattern: base62-encoded (A-Za-z0-9) identifiers.
+    /// </summary>
+    private static bool IsValidGiphyId(string giphyId)
+    {
+        if (string.IsNullOrWhiteSpace(giphyId))
+        {
+            return false;
+        }
+
+        // Giphy IDs are 16-20 alphanumeric characters
+        return giphyId.Length >= 14 && giphyId.Length <= 25 &&
+               System.Text.RegularExpressions.Regex.IsMatch(giphyId, "^[a-zA-Z0-9]+$");
     }
 
     private static string NormalizeRoomId(string roomId) => roomId.ToUpperInvariant();

--- a/PointerStar/Server/Room/InMemoryRoomManager.cs
+++ b/PointerStar/Server/Room/InMemoryRoomManager.cs
@@ -16,12 +16,14 @@ public class InMemoryRoomManager : IRoomManager
     private TelemetryClient TelemetryClient { get; }
     private IHubContext<RoomHub> HubContext { get; }
     private ILogger<InMemoryRoomManager> Logger { get; }
+    private TimeProvider TimeProvider { get; }
 
-    public InMemoryRoomManager(TelemetryClient telemetryClient, IHubContext<RoomHub> hubContext, ILogger<InMemoryRoomManager> logger)
+    public InMemoryRoomManager(TelemetryClient telemetryClient, IHubContext<RoomHub> hubContext, ILogger<InMemoryRoomManager> logger, TimeProvider timeProvider)
     {
         TelemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
         HubContext = hubContext ?? throw new ArgumentNullException(nameof(hubContext));
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        TimeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
     public Task<RoomState> AddUserToRoomAsync(string roomId, User user, string connectionId)
@@ -116,30 +118,34 @@ public class InMemoryRoomManager : IRoomManager
         var cts = new CancellationTokenSource();
         PendingDisconnects[userId] = cts;
 
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                await Task.Delay(delay, cts.Token);
-                RoomState? room = await RemoveUserFromRoomAsync(NormalizeRoomId(roomId), userId);
-                if (room is not null)
-                {
-                    await HubContext.Clients.Group(NormalizeRoomId(room.RoomId))
-                        .SendAsync(RoomHubConnection.RoomUpdatedMethodName, room);
-                }
-            }
-            catch (OperationCanceledException) { }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "Error during deferred disconnect for user {UserId} in room {RoomId}", userId, roomId);
-            }
-            finally
-            {
-                PendingDisconnects.TryRemove(userId, out _);
-            }
-        });
+        // Start the deferred disconnect. The method executes synchronously until the first
+        // await, so the timer is registered with TimeProvider before this method returns.
+        _ = RunDeferredDisconnectAsync(userId, roomId, delay, cts);
 
         return Task.CompletedTask;
+    }
+
+    private async Task RunDeferredDisconnectAsync(Guid userId, string roomId, TimeSpan delay, CancellationTokenSource cts)
+    {
+        try
+        {
+            await Task.Delay(delay, TimeProvider, cts.Token);
+            RoomState? room = await RemoveUserFromRoomAsync(NormalizeRoomId(roomId), userId);
+            if (room is not null)
+            {
+                await HubContext.Clients.Group(NormalizeRoomId(room.RoomId))
+                    .SendAsync(RoomHubConnection.RoomUpdatedMethodName, room);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error during deferred disconnect for user {UserId} in room {RoomId}", userId, roomId);
+        }
+        finally
+        {
+            PendingDisconnects.TryRemove(userId, out _);
+        }
     }
 
     public void CancelPendingDisconnect(Guid userId)

--- a/PointerStar/Server/Room/InMemoryRoomManager.cs
+++ b/PointerStar/Server/Room/InMemoryRoomManager.cs
@@ -181,10 +181,17 @@ public class InMemoryRoomManager : IRoomManager
                     room = room with { VoteOptions = voteOptions };
                 }
 
-                // Prevent voting mode changes mid-session (mode is immutable after room creation)
                 if (roomOptions.VotingMode.HasValue && roomOptions.VotingMode != room.VotingMode)
                 {
-                    Logger.LogWarning("Attempt to change voting mode mid-session for room {RoomId} (not allowed)", room.RoomId);
+                    room = room with
+                    {
+                        VotingMode = roomOptions.VotingMode.Value,
+                        Users = [.. room.Users.Select(u => u with { Vote = null, OriginalVote = null })],
+                        VotesShown = false,
+                        VoteStartTime = DateTime.UtcNow,
+                        ResetVotesRequestedAt = null,
+                        ResetVotesRequestedBy = null,
+                    };
                 }
 
                 return room;
@@ -461,9 +468,8 @@ public class InMemoryRoomManager : IRoomManager
     }
 
     /// <summary>
-    /// Validates that a vote is a properly formatted Giphy ID.
-    /// Giphy IDs are alphanumeric strings, typically 16-20 characters.
-    /// Pattern: base62-encoded (A-Za-z0-9) identifiers.
+    /// Validates that a vote is a reasonably formatted Giphy ID.
+    /// Giphy IDs returned by the API vary in length, so avoid strict length assumptions.
     /// </summary>
     private static bool IsValidGiphyId(string giphyId)
     {
@@ -472,9 +478,11 @@ public class InMemoryRoomManager : IRoomManager
             return false;
         }
 
-        // Giphy IDs are 16-20 alphanumeric characters
-        return giphyId.Length >= 14 && giphyId.Length <= 25 &&
-               System.Text.RegularExpressions.Regex.IsMatch(giphyId, "^[a-zA-Z0-9]+$");
+        string normalizedId = giphyId.Trim();
+
+        // Accept a practical max length and common identifier characters from API responses.
+        return normalizedId.Length <= 128 &&
+               System.Text.RegularExpressions.Regex.IsMatch(normalizedId, "^[a-zA-Z0-9_-]+$");
     }
 
     private static string NormalizeRoomId(string roomId) => roomId.ToUpperInvariant();

--- a/PointerStar/Shared/RoomOptions.cs
+++ b/PointerStar/Shared/RoomOptions.cs
@@ -5,4 +5,5 @@ public record class RoomOptions
     public bool? VotesShown { get; init; }
     public bool? AutoShowVotes { get; init; }
     public string[]? VoteOptions { get; init; }
+    public VotingMode? VotingMode { get; init; }
 }

--- a/PointerStar/Shared/RoomState.cs
+++ b/PointerStar/Shared/RoomState.cs
@@ -19,6 +19,8 @@ public sealed record class RoomState(string RoomId, User[] Users)
     
     public DateTime? ResetVotesRequestedAt { get; init; }
     public Guid? ResetVotesRequestedBy { get; init; }
+
+    public VotingMode VotingMode { get; init; } = VotingMode.Standard;
 }
 
 public sealed record class User(Guid Id, string Name)

--- a/PointerStar/Shared/VotingMode.cs
+++ b/PointerStar/Shared/VotingMode.cs
@@ -1,0 +1,13 @@
+namespace PointerStar.Shared;
+
+/// <summary>
+/// Voting mode for a pointing poker room.
+/// </summary>
+public enum VotingMode
+{
+    /// <summary>Standard numeric voting (Fibonacci, T-shirt sizes, etc.)</summary>
+    Standard = 0,
+
+    /// <summary>Giphy image voting (cosmetic/icebreaker mode).</summary>
+    Giphy = 1
+}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ dotnet build --configuration Release
 dotnet run --project PointerStar/AppHost/PointerStar.AppHost.csproj
 ```
 
+For local Giphy search support, set the API key in **user secrets** for the server project:
+
+```powershell
+cd PointerStar/Server
+dotnet user-secrets set "Giphy:ApiKey" "<your-giphy-api-key>"
+```
+
+Production deployments read `GIPHY_API_KEY` from the app's environment, which is set by the GitHub Actions `GIPHY_API_KEY` secret during deploy.
+
 ## Publish the hosted app
 
 ```powershell

--- a/Tests/PointerStar.Server.Tests/Controllers/ClientConfigControllerTests.cs
+++ b/Tests/PointerStar.Server.Tests/Controllers/ClientConfigControllerTests.cs
@@ -2,8 +2,9 @@ using PointerStar.Server.Controllers;
 
 namespace PointerStar.Server.Tests.Controllers;
 
+[Collection(WebAppCollection.Name)]
 [ConstructorTests(typeof(ClientConfigController))]
-public partial class ClientConfigControllerTests(WebApplicationFactory factory) : IClassFixture<WebApplicationFactory>
+public partial class ClientConfigControllerTests(WebApplicationFactory factory)
 {
     private sealed record ClientConfigResponse(
         string? ApplicationInsightsConnectionString,

--- a/Tests/PointerStar.Server.Tests/Controllers/RoomControllerTests.cs
+++ b/Tests/PointerStar.Server.Tests/Controllers/RoomControllerTests.cs
@@ -1,11 +1,13 @@
-﻿using PointerStar.Server.Controllers;
+﻿using Microsoft.Extensions.DependencyInjection;
+using PointerStar.Server.Controllers;
 using PointerStar.Server.Room;
 using PointerStar.Shared;
 
 namespace PointerStar.Server.Tests.Controllers;
 
+[Collection(WebAppCollection.Name)]
 [ConstructorTests(typeof(RoomController))]
-public partial class RoomControllerTests(WebApplicationFactory factory) : IClassFixture<WebApplicationFactory>
+public partial class RoomControllerTests(WebApplicationFactory factory)
 {
     private WebApplicationFactory Factory { get; } = factory;
 
@@ -25,14 +27,15 @@ public partial class RoomControllerTests(WebApplicationFactory factory) : IClass
     [Fact]
     public async Task GetNewUserRole_GetsRoleFromManager()
     {
-        AutoMocker mocker = new();
-        mocker.Setup<IRoomManager, Task<Role>>(x => x.GetNewUserRoleAsync("room"))
-            .ReturnsAsync(Role.TeamMember);
-        Factory.UseService(mocker.Get<IRoomManager>());
-        HttpClient client = Factory.CreateClient();
+        string roomId = Guid.NewGuid().ToString();
+        var roomManager = Factory.Services.GetRequiredService<IRoomManager>();
+        await roomManager.AddUserToRoomAsync(roomId,
+            new User(Guid.NewGuid(), "Facilitator") { Role = Role.Facilitator },
+            Guid.NewGuid().ToString());
 
-        var role = await client.GetFromJsonAsync<Role>("/api/room/GetNewUserRole/room");
-        
+        HttpClient client = Factory.CreateClient();
+        var role = await client.GetFromJsonAsync<Role>($"/api/room/GetNewUserRole/{roomId}");
+
         Assert.Equal(Role.TeamMember, role);
     }
 }

--- a/Tests/PointerStar.Server.Tests/Controllers/WebAppCollection.cs
+++ b/Tests/PointerStar.Server.Tests/Controllers/WebAppCollection.cs
@@ -1,0 +1,9 @@
+using PointerStar.Server.Tests;
+
+namespace PointerStar.Server.Tests.Controllers;
+
+[CollectionDefinition(Name)]
+public class WebAppCollection : ICollectionFixture<WebApplicationFactory>
+{
+    public const string Name = "WebApp";
+}

--- a/Tests/PointerStar.Server.Tests/PointerStar.Server.Tests.csproj
+++ b/Tests/PointerStar.Server.Tests/PointerStar.Server.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />

--- a/Tests/PointerStar.Server.Tests/Room/InMemoryRoomManagerTests.cs
+++ b/Tests/PointerStar.Server.Tests/Room/InMemoryRoomManagerTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using PointerStar.Server.Hubs;
 using PointerStar.Server.Room;
@@ -12,6 +13,7 @@ public partial class InMemoryRoomManagerTests : RoomManagerTests<InMemoryRoomMan
     partial void AutoMockerTestSetup(AutoMocker mocker, string testName)
     {
         UseTestTelemetry(mocker);
+        mocker.Use(TimeProvider.System);
         SetupHubContext(mocker);
     }
 
@@ -33,6 +35,7 @@ public partial class InMemoryRoomManagerTests : RoomManagerTests<InMemoryRoomMan
     {
         AutoMocker mocker = new();
         UseTestTelemetry(mocker);
+        mocker.Use(TimeProvider.System);
         SetupHubContext(mocker);
 
         string connectionId = Guid.NewGuid().ToString();
@@ -53,6 +56,7 @@ public partial class InMemoryRoomManagerTests : RoomManagerTests<InMemoryRoomMan
     {
         AutoMocker mocker = new();
         UseTestTelemetry(mocker);
+        mocker.Use(TimeProvider.System);
         SetupHubContext(mocker);
 
         IRoomManager sut = mocker.CreateInstance<InMemoryRoomManager>();
@@ -69,6 +73,8 @@ public partial class InMemoryRoomManagerTests : RoomManagerTests<InMemoryRoomMan
     {
         AutoMocker mocker = new();
         UseTestTelemetry(mocker);
+        var fakeTimeProvider = new FakeTimeProvider();
+        mocker.Use<TimeProvider>(fakeTimeProvider);
         SetupHubContext(mocker);
 
         string connectionId = Guid.NewGuid().ToString();
@@ -80,8 +86,9 @@ public partial class InMemoryRoomManagerTests : RoomManagerTests<InMemoryRoomMan
         sut.TryReleaseConnection(connectionId, out string? roomId, out Guid userId);
         Assert.NotNull(roomId);
 
-        await sut.ScheduleDisconnectAsync(userId, roomId, TimeSpan.FromMilliseconds(50));
-        await Task.Delay(500);
+        await sut.ScheduleDisconnectAsync(userId, roomId, TimeSpan.FromMinutes(1));
+        fakeTimeProvider.Advance(TimeSpan.FromMinutes(1));
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
 
         // After the grace period, the facilitator should be removed.
         // Disconnecting the team member now leaves an empty room (returns null).
@@ -94,6 +101,8 @@ public partial class InMemoryRoomManagerTests : RoomManagerTests<InMemoryRoomMan
     {
         AutoMocker mocker = new();
         UseTestTelemetry(mocker);
+        var fakeTimeProvider = new FakeTimeProvider();
+        mocker.Use<TimeProvider>(fakeTimeProvider);
         SetupHubContext(mocker);
 
         string connectionId = Guid.NewGuid().ToString();
@@ -105,9 +114,10 @@ public partial class InMemoryRoomManagerTests : RoomManagerTests<InMemoryRoomMan
         sut.TryReleaseConnection(connectionId, out string? roomId, out Guid userId);
         Assert.NotNull(roomId);
 
-        await sut.ScheduleDisconnectAsync(userId, roomId, TimeSpan.FromMilliseconds(300));
+        await sut.ScheduleDisconnectAsync(userId, roomId, TimeSpan.FromMinutes(1));
         sut.CancelPendingDisconnect(userId);
-        await Task.Delay(500);
+        fakeTimeProvider.Advance(TimeSpan.FromMinutes(1));
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
 
         // Grace period was cancelled so facilitator should still be in the room.
         // Disconnecting the team member should return the room still containing the facilitator.

--- a/Tests/PointerStar.Server.Tests/Room/RoomManagerTests.cs
+++ b/Tests/PointerStar.Server.Tests/Room/RoomManagerTests.cs
@@ -165,6 +165,33 @@ public abstract class RoomManagerTests<TRoomManager>
         Assert.Null(roomState.Users.Single().OriginalVote);
     }
 
+    [Theory]
+    [InlineData("abc123xyz0")]
+    [InlineData("giphy_id-123")]
+    [InlineData("xT9IgDEI1iZyb2wqo8")]
+    public async Task SubmitVoteAsync_WithGiphyModeAndValidGiphyId_UpdatesVote(string giphyId)
+    {
+        AutoMocker mocker = new();
+        UseTestTelemetry(mocker);
+
+        string facilitatorConnectionId = Guid.NewGuid().ToString();
+        string teamMemberConnectionId = Guid.NewGuid().ToString();
+        IRoomManager sut = mocker.CreateInstance<TRoomManager>();
+        await CreateRoom(sut, facilitatorConnectionId, teamMemberConnectionId);
+
+        _ = await sut.UpdateRoomAsync(new RoomOptions
+        {
+            VotingMode = VotingMode.Giphy
+        }, facilitatorConnectionId);
+
+        RoomState? roomState = await sut.SubmitVoteAsync(giphyId, teamMemberConnectionId);
+
+        Assert.NotNull(roomState);
+        Assert.Single(roomState.TeamMembers);
+        Assert.Equal(giphyId, roomState.TeamMembers.Single().Vote);
+        Assert.Equal(giphyId, roomState.TeamMembers.Single().OriginalVote);
+    }
+
     [Fact]
     public async Task SubmitVoteAsync_AfterVotesShown_UpdatesVote()
     {
@@ -591,6 +618,58 @@ public abstract class RoomManagerTests<TRoomManager>
 
         Assert.NotNull(roomState);
         Assert.Equal(originalVoteOptions, roomState.VoteOptions);
+    }
+
+    [Fact]
+    public async Task UpdateRoomAsync_WithVotingModeChangeByFacilitator_ChangesModeAndResetsVotesAndTimer()
+    {
+        AutoMocker mocker = new();
+        UseTestTelemetry(mocker);
+
+        string facilitator = Guid.NewGuid().ToString();
+        string teamMember = Guid.NewGuid().ToString();
+        IRoomManager sut = mocker.CreateInstance<TRoomManager>();
+        RoomState room = await CreateRoom(sut, facilitator, teamMember);
+
+        _ = await sut.SubmitVoteAsync(room.VoteOptions.First(), teamMember);
+        _ = await sut.UpdateRoomAsync(new RoomOptions { VotesShown = true }, facilitator);
+
+        DateTime startedBeforeModeChange = DateTime.UtcNow;
+        RoomState? roomState = await sut.UpdateRoomAsync(new RoomOptions
+        {
+            VotingMode = VotingMode.Giphy
+        }, facilitator);
+
+        Assert.NotNull(roomState);
+        Assert.Equal(VotingMode.Giphy, roomState.VotingMode);
+        Assert.False(roomState.VotesShown);
+        Assert.All(roomState.Users, user =>
+        {
+            Assert.Null(user.Vote);
+            Assert.Null(user.OriginalVote);
+        });
+        Assert.True(roomState.VoteStartTime.HasValue);
+        Assert.True(roomState.VoteStartTime.Value >= startedBeforeModeChange);
+    }
+
+    [Fact]
+    public async Task UpdateRoomAsync_WithVotingModeChangeByTeamMember_DoesNotChangeMode()
+    {
+        AutoMocker mocker = new();
+        UseTestTelemetry(mocker);
+
+        string facilitator = Guid.NewGuid().ToString();
+        string teamMember = Guid.NewGuid().ToString();
+        IRoomManager sut = mocker.CreateInstance<TRoomManager>();
+        await CreateRoom(sut, facilitator, teamMember);
+
+        RoomState? roomState = await sut.UpdateRoomAsync(new RoomOptions
+        {
+            VotingMode = VotingMode.Giphy
+        }, teamMember);
+
+        Assert.NotNull(roomState);
+        Assert.Equal(VotingMode.Standard, roomState.VotingMode);
     }
 
     [Fact]


### PR DESCRIPTION
The `automerge` job in the CI workflow was failing with `PR does not contain metadata, nothing to do.` when triggered by non-Dependabot PRs. This is because `fastify/github-action-merge-dependabot` only works on PRs opened by Dependabot — it looks for Dependabot-specific commit metadata that doesn't exist on other PRs.

## Root Cause

The `automerge` job's `if` condition only checked `github.event_name == 'pull_request'`, so it ran on every PR regardless of the author.

## Fix

Added `github.actor == 'dependabot[bot]'` to the `automerge` job's `if` condition in `.github/workflows/main_pointerstar.yml`, so the job is skipped on non-Dependabot PRs instead of failing.