### PR TITLE
Allow Enter key to submit user name dialog

### DIFF
--- a/PointerStar/ClientApp/src/components/UserDialog.tsx
+++ b/PointerStar/ClientApp/src/components/UserDialog.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react'
+import { type FormEvent, useEffect, useState } from 'react'
 import {
+  Box,
   Button,
   ButtonGroup,
   CircularProgress,
@@ -72,59 +73,62 @@ export function UserDialog({
     }
   }, [open, roomId, selectedRoleId])
 
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    onSubmit({ name: name.trim(), selectedRoleId })
+  }
+
   return (
     <Dialog fullWidth maxWidth="sm" onClose={onCancel} open={open}>
-      <DialogContent>
-        <Stack spacing={2}>
-          <TextField
-            fullWidth
-            label="Name"
-            onChange={(event) => setName(event.target.value)}
-            slotProps={{ htmlInput: { maxLength: userNameMaxLength } }}
-            value={name}
-            variant="standard"
-          />
-          <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
-            <Typography>I want to...</Typography>
-            <ButtonGroup>
-              <Button
-                disabled={isLoading}
-                onClick={() => setSelectedRoleId(roles.teamMember.id)}
-                variant={selectedRoleId === roles.teamMember.id ? 'contained' : 'outlined'}
-              >
-                Vote
-              </Button>
-              <Button
-                disabled={isLoading}
-                onClick={() => setSelectedRoleId(roles.facilitator.id)}
-                variant={selectedRoleId === roles.facilitator.id ? 'contained' : 'outlined'}
-              >
-                Facilitate
-              </Button>
-              <Button
-                disabled={isLoading}
-                onClick={() => setSelectedRoleId(roles.observer.id)}
-                variant={selectedRoleId === roles.observer.id ? 'contained' : 'outlined'}
-              >
-                Observe
-              </Button>
-            </ButtonGroup>
-            {isLoading ? <CircularProgress size={18} /> : null}
+      <Box component="form" onSubmit={handleSubmit}>
+        <DialogContent>
+          <Stack spacing={2}>
+            <TextField
+              fullWidth
+              label="Name"
+              onChange={(event) => setName(event.target.value)}
+              slotProps={{ htmlInput: { maxLength: userNameMaxLength } }}
+              value={name}
+              variant="standard"
+            />
+            <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
+              <Typography>I want to...</Typography>
+              <ButtonGroup>
+                <Button
+                  disabled={isLoading}
+                  onClick={() => setSelectedRoleId(roles.teamMember.id)}
+                  variant={selectedRoleId === roles.teamMember.id ? 'contained' : 'outlined'}
+                >
+                  Vote
+                </Button>
+                <Button
+                  disabled={isLoading}
+                  onClick={() => setSelectedRoleId(roles.facilitator.id)}
+                  variant={selectedRoleId === roles.facilitator.id ? 'contained' : 'outlined'}
+                >
+                  Facilitate
+                </Button>
+                <Button
+                  disabled={isLoading}
+                  onClick={() => setSelectedRoleId(roles.observer.id)}
+                  variant={selectedRoleId === roles.observer.id ? 'contained' : 'outlined'}
+                >
+                  Observe
+                </Button>
+              </ButtonGroup>
+              {isLoading ? <CircularProgress size={18} /> : null}
+            </Stack>
           </Stack>
-        </Stack>
-      </DialogContent>
-      <DialogActions>
-        <Button disabled={isLoading} onClick={onCancel}>
-          Cancel
-        </Button>
-        <Button
-          disabled={isLoading}
-          onClick={() => onSubmit({ name: name.trim(), selectedRoleId })}
-          variant="contained"
-        >
-          Ok
-        </Button>
-      </DialogActions>
+        </DialogContent>
+        <DialogActions>
+          <Button disabled={isLoading} onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button disabled={isLoading} type="submit" variant="contained">
+            Ok
+          </Button>
+        </DialogActions>
+      </Box>
     </Dialog>
   )
 }


### PR DESCRIPTION
## What
Enable the Enter key to submit the user name dialog and role selection by routing keyboard submission through the OK button.

## Why
Users expect the Enter key to submit dialog forms—this is standard UX behavior for modal dialogs. Without this, they must click the OK button or Tab to it and press Enter.

## How
- Wrapped the dialog content in a `<Box component="form">` with an `onSubmit` handler
- Changed the OK button to `type="submit"` instead of an `onClick` handler
- The submit handler preserves the existing name-trimming and role-selection logic

Tests pass; dialog behavior is unchanged except for the new Enter key support.