### PR TITLE
Add Show More pagination for GIPHY search results

### DIFF
--- a/PointerStar/ClientApp/src/components/GiphyVotingPanel.test.tsx
+++ b/PointerStar/ClientApp/src/components/GiphyVotingPanel.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GiphyVotingPanel } from './GiphyVotingPanel'
+import { GIPHY_PAGE_SIZE, searchGiphy } from '../services/giphyApi'
+
+vi.mock('../services/giphyApi', () => ({
+  GIPHY_PAGE_SIZE: 20,
+  searchGiphy: vi.fn(),
+}))
+
+const searchGiphyMock = vi.mocked(searchGiphy)
+
+const createGif = (index: number) => ({
+  id: `gif-${index}`,
+  title: `GIF ${index}`,
+  imageUrl: `https://example.test/gif-${index}.gif`,
+})
+
+describe('GiphyVotingPanel', () => {
+  beforeEach(() => {
+    searchGiphyMock.mockReset()
+  })
+
+  it('loads the next result page when show more is clicked', async () => {
+    searchGiphyMock
+      .mockResolvedValueOnce({
+        data: Array.from({ length: GIPHY_PAGE_SIZE }, (_, index) => createGif(index + 1)),
+        pagination: {
+          count: GIPHY_PAGE_SIZE,
+          offset: 0,
+          totalCount: GIPHY_PAGE_SIZE * 2,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: Array.from({ length: GIPHY_PAGE_SIZE }, (_, index) => createGif(index + GIPHY_PAGE_SIZE + 1)),
+        pagination: {
+          count: GIPHY_PAGE_SIZE,
+          offset: GIPHY_PAGE_SIZE,
+          totalCount: GIPHY_PAGE_SIZE * 2,
+        },
+      })
+
+    render(<GiphyVotingPanel onVoteSubmit={vi.fn()} />)
+
+    fireEvent.change(screen.getByPlaceholderText('Search for a GIF...'), {
+      target: { value: 'cat' },
+    })
+
+    await waitFor(() => {
+      expect(searchGiphyMock).toHaveBeenCalledWith({
+        query: 'cat',
+        offset: 0,
+      })
+    }, { timeout: 3000 })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Show More' }))
+
+    await waitFor(() => {
+      expect(searchGiphyMock).toHaveBeenLastCalledWith({
+        query: 'cat',
+        offset: GIPHY_PAGE_SIZE,
+      })
+    })
+
+    expect(await screen.findByAltText('GIF 21')).toBeInTheDocument()
+  })
+})

--- a/PointerStar/ClientApp/src/components/GiphyVotingPanel.tsx
+++ b/PointerStar/ClientApp/src/components/GiphyVotingPanel.tsx
@@ -15,7 +15,7 @@ import {
 import CloseIcon from '@mui/icons-material/Close'
 import SearchIcon from '@mui/icons-material/Search'
 import type { GiphyItem } from '../types/contracts'
-import { searchGiphy } from '../services/giphyApi'
+import { GIPHY_PAGE_SIZE, searchGiphy } from '../services/giphyApi'
 
 interface GiphyVotingPanelProps {
   currentVote?: string | null
@@ -31,40 +31,81 @@ export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({ currentVote,
   const [searchQuery, setSearchQuery] = useState('')
   const [results, setResults] = useState<GiphyItem[]>([])
   const [loading, setLoading] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [isSearchExpanded, setIsSearchExpanded] = useState(!currentVote)
+  const [activeQuery, setActiveQuery] = useState('')
+  const [nextOffset, setNextOffset] = useState(0)
+  const [hasMoreResults, setHasMoreResults] = useState(false)
   const requestIdRef = useRef(0)
 
   const handleSearch = useCallback(
-    async (query: string) => {
-      if (!query.trim()) {
+    async (query: string, offset = 0, append = false) => {
+      const trimmedQuery = query.trim()
+      if (!trimmedQuery) {
         setResults([])
         setError(null)
+        setActiveQuery('')
+        setNextOffset(0)
+        setHasMoreResults(false)
         return
       }
 
-      setLoading(true)
+      if (append) {
+        setLoadingMore(true)
+      } else {
+        setLoading(true)
+        setResults([])
+        setNextOffset(0)
+        setHasMoreResults(false)
+        setActiveQuery(trimmedQuery)
+      }
       setError(null)
 
       try {
         const requestId = ++requestIdRef.current
-        const response = await searchGiphy(query)
+        const response = await searchGiphy({
+          query: trimmedQuery,
+          offset,
+        })
         if (requestId !== requestIdRef.current) {
           return
         }
 
-        setResults(response.data || [])
+        const nextPageResults = response.data ?? []
+        const responseCount = response.pagination?.count ?? nextPageResults.length
+        const responseOffset = response.pagination?.offset ?? offset
+        const calculatedNextOffset = responseOffset + responseCount
+        const knownTotal = response.pagination?.totalCount
 
-        if (response.data?.length === 0) {
+        setNextOffset(calculatedNextOffset)
+        setHasMoreResults(
+          knownTotal !== undefined
+            ? calculatedNextOffset < knownTotal
+            : nextPageResults.length === GIPHY_PAGE_SIZE,
+        )
+
+        if (append) {
+          setResults((currentResults) => [...currentResults, ...nextPageResults])
+        } else {
+          setResults(nextPageResults)
+        }
+
+        if (!append && nextPageResults.length === 0) {
           setError('No GIFs found. Try a different search.')
         }
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : 'Search failed'
         setError(errorMessage)
-        setResults([])
+        if (!append) {
+          setResults([])
+          setNextOffset(0)
+          setHasMoreResults(false)
+        }
       } finally {
         setLoading(false)
+        setLoadingMore(false)
       }
     },
     []
@@ -76,6 +117,10 @@ export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({ currentVote,
     setResults([])
     setError(null)
     setLoading(false)
+    setLoadingMore(false)
+    setActiveQuery('')
+    setNextOffset(0)
+    setHasMoreResults(false)
   }, [])
 
   useEffect(() => {
@@ -109,6 +154,14 @@ export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({ currentVote,
     setIsSearchExpanded(false)
     onVoteSubmit(giphyId)
   }
+
+  const handleShowMore = useCallback(() => {
+    if (loading || loadingMore || !hasMoreResults || !activeQuery) {
+      return
+    }
+
+    void handleSearch(activeQuery, nextOffset, true)
+  }, [activeQuery, handleSearch, hasMoreResults, loading, loadingMore, nextOffset])
 
   return (
     <Box>
@@ -201,6 +254,17 @@ export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({ currentVote,
                   </ImageListItem>
                 ))}
               </ImageList>
+              {hasMoreResults ? (
+                <Box sx={{ display: 'flex', justifyContent: 'center', pb: 1, pt: 2 }}>
+                  <Button
+                    onClick={handleShowMore}
+                    disabled={loadingMore}
+                    variant="outlined"
+                  >
+                    {loadingMore ? 'Loading…' : 'Show More'}
+                  </Button>
+                </Box>
+              ) : null}
             </Paper>
           )}
 

--- a/PointerStar/ClientApp/src/services/giphyApi.ts
+++ b/PointerStar/ClientApp/src/services/giphyApi.ts
@@ -1,13 +1,33 @@
 import type { GiphySearchResponse } from '../types/contracts'
 
+export const GIPHY_PAGE_SIZE = 20
+
 /**
  * Service for interacting with the Giphy API endpoint.
  * Handles searching for Giphy images and error handling.
  */
 
-export async function searchGiphy(query: string): Promise<GiphySearchResponse> {
+interface SearchGiphyOptions {
+  query: string
+  offset?: number
+}
+
+export async function searchGiphy({ query, offset = 0 }: SearchGiphyOptions): Promise<GiphySearchResponse> {
+  const trimmedQuery = query.trim()
+  if (!trimmedQuery) {
+    return {
+      data: [],
+      pagination: null,
+    }
+  }
+
   try {
-    const response = await fetch(`/api/giphy/search?query=${encodeURIComponent(query)}`, {
+    const params = new URLSearchParams({
+      query: trimmedQuery,
+      offset: String(offset),
+    })
+
+    const response = await fetch(`/api/giphy/search?${params.toString()}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -25,7 +45,6 @@ export async function searchGiphy(query: string): Promise<GiphySearchResponse> {
     return data
   } catch (error) {
     console.error('Giphy search failed:', error)
-    // Return empty results on failure for graceful degradation
     return {
       data: [],
       pagination: null,

--- a/PointerStar/Server/Controllers/GiphyController.cs
+++ b/PointerStar/Server/Controllers/GiphyController.cs
@@ -16,6 +16,7 @@ namespace PointerStar.Server.Controllers;
 public class GiphyController(IHttpClientFactory httpClientFactory, IMemoryCache memoryCache, IConfiguration configuration) : ControllerBase
 {
     private const string GiphyApiBaseUrl = "https://api.giphy.com/v1";
+    private const int PageSize = 20;
     private const int RateLimitPerMinute = 10;
     private const int CacheDurationMinutes = 30;
 
@@ -30,11 +31,16 @@ public class GiphyController(IHttpClientFactory httpClientFactory, IMemoryCache 
     /// Results cached for 30 minutes.
     /// </summary>
     [HttpGet("Search")]
-    public async Task<ActionResult<GiphySearchResponse>> Search([FromQuery] string query)
+    public async Task<ActionResult<GiphySearchResponse>> Search([FromQuery] string query, [FromQuery] int offset = 0)
     {
         if (string.IsNullOrWhiteSpace(query))
         {
             return BadRequest(new { error = "Query parameter is required" });
+        }
+
+        if (offset < 0)
+        {
+            return BadRequest(new { error = "Offset must be zero or greater." });
         }
 
         // Rate limiting: check if user has exceeded the limit
@@ -45,7 +51,7 @@ public class GiphyController(IHttpClientFactory httpClientFactory, IMemoryCache 
         }
 
         // Check cache first
-        string cacheKey = $"giphy_search_{query.ToLower()}";
+        string cacheKey = $"giphy_search_{query.ToLower()}_{offset}";
         if (MemoryCache.TryGetValue(cacheKey, out GiphySearchResponse? cachedResult))
         {
             return cachedResult!;
@@ -60,7 +66,7 @@ public class GiphyController(IHttpClientFactory httpClientFactory, IMemoryCache 
         try
         {
             using var httpClient = HttpClientFactory.CreateClient();
-            string url = $"{GiphyApiBaseUrl}/gifs/search?api_key={giphyApiKey}&q={Uri.EscapeDataString(query)}&limit=21&offset=0&rating=g&lang=en";
+            string url = $"{GiphyApiBaseUrl}/gifs/search?api_key={giphyApiKey}&q={Uri.EscapeDataString(query)}&limit={PageSize}&offset={offset}&rating=g&lang=en";
 
             using var response = await httpClient.GetAsync(url);
             if (!response.IsSuccessStatusCode)
@@ -78,7 +84,7 @@ public class GiphyController(IHttpClientFactory httpClientFactory, IMemoryCache 
             var result = new GiphySearchResponse
             {
                 Data = ExtractGiphyIds(root),
-                Pagination = new PaginationInfo { Count = 21 }
+                Pagination = ExtractPaginationInfo(root, offset)
             };
 
             // Cache the result
@@ -126,6 +132,50 @@ public class GiphyController(IHttpClientFactory httpClientFactory, IMemoryCache 
         UserSearchTimestamps[userId] = newTimestamps;
 
         return true;
+    }
+
+    private static PaginationInfo ExtractPaginationInfo(JsonElement root, int requestedOffset)
+    {
+        if (root.TryGetProperty("pagination", out var paginationElement))
+        {
+            int count = 0;
+            int offset = requestedOffset;
+            int totalCount = 0;
+
+            if (paginationElement.TryGetProperty("count", out var countElement))
+            {
+                count = countElement.GetInt32();
+            }
+
+            if (paginationElement.TryGetProperty("offset", out var offsetElement))
+            {
+                offset = offsetElement.GetInt32();
+            }
+
+            if (paginationElement.TryGetProperty("total_count", out var totalCountElement))
+            {
+                totalCount = totalCountElement.GetInt32();
+            }
+
+            if (totalCount == 0 && count > 0)
+            {
+                totalCount = offset + count;
+            }
+
+            return new PaginationInfo
+            {
+                Count = count,
+                Offset = offset,
+                TotalCount = totalCount
+            };
+        }
+
+        return new PaginationInfo
+        {
+            Count = 0,
+            Offset = requestedOffset,
+            TotalCount = 0
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
## Why
The GIF voting search only returned the first page of results, so users quickly ran out of options for common search terms. This adds a way to continue browsing without changing the current query.

## What changed
- Added paginated loading in `GiphyVotingPanel` with a **Show More** button that requests and appends the next page of GIFs.
- Updated the client Giphy API service to send `offset` along with `query` when searching.
- Updated `GiphyController` to accept `offset`, forward it to the upstream Giphy API, and return pagination metadata for the client.
- Included offset in the server cache key so each page is cached independently.
- Added a component test (`GiphyVotingPanel.test.tsx`) that verifies next-page loading behavior and offset progression.

## Notes for reviewers
- Existing debounce/search interaction remains in place; this change is scoped to paging and appending results for the active query.
- If upstream pagination metadata is unavailable, the client falls back to page-size-based behavior for whether to show **Show More**.