### PR TITLE
Add "facilitator can vote" option to room configuration

### DIFF
--- a/PointerStar/ClientApp/src/components/VotingOptionsDialog.tsx
+++ b/PointerStar/ClientApp/src/components/VotingOptionsDialog.tsx
@@ -7,11 +7,13 @@ import {
 } from '@mui/icons-material'
 import {
   Button,
+  Checkbox,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   Divider,
+  FormControlLabel,
   IconButton,
   Stack,
   TextField,
@@ -21,10 +23,11 @@ import {
 import { defaultVoteOptions, votingPresets, VotingMode } from '../types/contracts'
 
 interface VotingOptionsDialogProps {
+  currentFacilitatorCanVote?: boolean
   currentVoteOptions?: string[]
   currentVotingMode?: VotingMode
   onCancel: () => void
-  onSave: (voteOptions: string[], votingMode?: VotingMode) => void
+  onSave: (voteOptions: string[], votingMode?: VotingMode, facilitatorCanVote?: boolean) => void
   open: boolean
 }
 
@@ -36,6 +39,7 @@ function isPresetSelected(currentVoteOptions: string[], preset: readonly string[
 }
 
 export function VotingOptionsDialog({
+  currentFacilitatorCanVote,
   currentVoteOptions,
   currentVotingMode,
   onCancel,
@@ -44,6 +48,7 @@ export function VotingOptionsDialog({
 }: VotingOptionsDialogProps) {
   const [voteOptions, setVoteOptions] = useState<string[]>(currentVoteOptions ?? [...defaultVoteOptions])
   const [votingMode, setVotingMode] = useState<VotingMode>(currentVotingMode ?? VotingMode.Standard)
+  const [facilitatorCanVote, setFacilitatorCanVote] = useState(currentFacilitatorCanVote ?? false)
 
   useEffect(() => {
     if (!open) {
@@ -52,7 +57,8 @@ export function VotingOptionsDialog({
 
     setVoteOptions(currentVoteOptions ? [...currentVoteOptions] : [...defaultVoteOptions])
     setVotingMode(currentVotingMode ?? VotingMode.Standard)
-  }, [currentVoteOptions, currentVotingMode, open])
+    setFacilitatorCanVote(currentFacilitatorCanVote ?? false)
+  }, [currentFacilitatorCanVote, currentVoteOptions, currentVotingMode, open])
 
   const isValid = useMemo(
     () => {
@@ -69,6 +75,16 @@ export function VotingOptionsDialog({
       <DialogTitle>Configure Voting Options</DialogTitle>
       <DialogContent sx={{ pt: 2 }}>
         <Stack spacing={3}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={facilitatorCanVote}
+                onChange={(event) => setFacilitatorCanVote(event.target.checked)}
+              />
+            }
+            label="Allow facilitator to vote"
+          />
+
           <Stack spacing={1}>
             <Typography variant="body2">Select a preset:</Typography>
             <Stack direction="row" sx={{ flexWrap: 'wrap', gap: 1 }}>
@@ -185,7 +201,7 @@ export function VotingOptionsDialog({
         <Button onClick={onCancel}>Cancel</Button>
         <Button
           disabled={!isValid}
-          onClick={() => onSave(votingMode === VotingMode.Giphy ? [] : voteOptions.map((option) => option.trim()), votingMode)}
+          onClick={() => onSave(votingMode === VotingMode.Giphy ? [] : voteOptions.map((option) => option.trim()), votingMode, facilitatorCanVote)}
           variant="contained"
         >
           Save

--- a/PointerStar/ClientApp/src/pages/RoomPage.tsx
+++ b/PointerStar/ClientApp/src/pages/RoomPage.tsx
@@ -80,6 +80,7 @@ export function RoomPage() {
   const [votesShown, setVotesShown] = useState(false)
   const [previewVotes, setPreviewVotes] = useState(true)
   const [autoShowVotes, setAutoShowVotes] = useState(false)
+  const [facilitatorCanVote, setFacilitatorCanVote] = useState(false)
   const [voteStartTime, setVoteStartTime] = useState<string | null>(null)
   const [resetVotesRequestedAt, setResetVotesRequestedAt] = useState<string | null>(null)
   const [resetVotesRequestedBy, setResetVotesRequestedBy] = useState<string | null>(null)
@@ -125,6 +126,10 @@ export function RoomPage() {
     () => roomState?.users.filter((user) => user.role.id === roles.facilitator.id) ?? [],
     [roomState],
   )
+  const votingMembers = useMemo(
+    () => (facilitatorCanVote ? [...teamMembers, ...facilitators] : teamMembers),
+    [facilitatorCanVote, teamMembers, facilitators],
+  )
   const observers = useMemo(
     () => roomState?.users.filter((user) => user.role.id === roles.observer.id) ?? [],
     [roomState],
@@ -152,7 +157,7 @@ export function RoomPage() {
     }
 
     const counts = new Map<string, number>()
-    for (const member of teamMembers) {
+    for (const member of votingMembers) {
       const vote = member.vote ?? ''
       counts.set(vote, (counts.get(vote) ?? 0) + 1)
     }
@@ -165,7 +170,7 @@ export function RoomPage() {
         return (leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex) -
           (rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex)
       })
-  }, [roomState, teamMembers, votesShown])
+  }, [roomState, votingMembers, votesShown])
 
   const maxVoteCount = useMemo(
     () => groupedVotes.reduce((max, entry) => Math.max(max, entry.count), 0),
@@ -278,6 +283,7 @@ export function RoomPage() {
 
     const unsubscribe = client.subscribe((nextRoomState) => {
       setAutoShowVotes(nextRoomState.autoShowVotes)
+      setFacilitatorCanVote(nextRoomState.facilitatorCanVote)
       setResetVotesRequestedAt(nextRoomState.resetVotesRequestedAt ?? null)
       setResetVotesRequestedBy(nextRoomState.resetVotesRequestedBy ?? null)
       setRoomState(nextRoomState)
@@ -529,7 +535,7 @@ export function RoomPage() {
           </Alert>
         ) : null}
 
-        {isRole(currentUser, roles.teamMember) ? (
+        {isRole(currentUser, roles.teamMember) || (facilitatorCanVote && isRole(currentUser, roles.facilitator)) ? (
           <>
             {roomState?.votingMode === VotingMode.Giphy ? (
               <GiphyVotingPanel
@@ -592,16 +598,18 @@ export function RoomPage() {
               }
               label="Automatically reveal votes"
             />
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={previewVotes}
-                  color="info"
-                  onChange={(event) => setPreviewVotes(event.target.checked)}
-                />
-              }
-              label="Preview votes"
-            />
+            {!facilitatorCanVote ? (
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={previewVotes}
+                    color="info"
+                    onChange={(event) => setPreviewVotes(event.target.checked)}
+                  />
+                }
+                label="Preview votes"
+              />
+            ) : null}
             <Button color="warning" onClick={() => void handleResetVotes()} variant="contained">
               Reset Votes
             </Button>
@@ -630,7 +638,7 @@ export function RoomPage() {
               <Card>
                 <CardHeader title="Votes" />
                 <CardContent>
-                  <GiphyVoteDisplay users={teamMembers} showVotes={votesShown} />
+                  <GiphyVoteDisplay users={votingMembers} showVotes={votesShown} />
                 </CardContent>
               </Card>
             ) : (
@@ -639,7 +647,7 @@ export function RoomPage() {
                 <CardContent>
                   <Stack spacing={1}>
                     {groupedVotes.map((entry) => {
-                      const percentage = teamMembers.length === 0 ? 0 : entry.count / teamMembers.length
+                      const percentage = votingMembers.length === 0 ? 0 : entry.count / votingMembers.length
                       const isHighestCount = entry.count === maxVoteCount
                       const label = `${entry.vote.trim() ? entry.vote : '…'} - ${entry.count} Vote${entry.count === 1 ? '' : 's'} (${percentage.toLocaleString(undefined, { style: 'percent', maximumFractionDigits: 0 })})`
 
@@ -667,24 +675,27 @@ export function RoomPage() {
         <Card>
           <CardHeader title="Team Members" />
           <CardContent>
-            {teamMembers.length > 0 ? (
+            {votingMembers.length > 0 ? (
               <Stack spacing={1}>
-                {teamMembers.map((user) => (
+                {votingMembers.map((user) => (
                   <Typography key={user.id}>
                     {isRole(currentUser, roles.facilitator) ? (
-                      <Tooltip title={`Make ${user.name} an Observer`}>
-                        <IconButton
-                          color="inherit"
-                          onClick={() => {
-                            void callHub(async (client) => {
-                              await client.removeUser(user.id)
-                            })
-                          }}
-                          size="small"
-                          sx={{ mr: 0.5 }}
-                        >
-                          <RemoveUserIcon fontSize="small" />
-                        </IconButton>
+                      <Tooltip title={isRole(user, roles.facilitator) ? `${user.name} is a facilitator` : `Make ${user.name} an Observer`}>
+                        <span>
+                          <IconButton
+                            color="inherit"
+                            disabled={isRole(user, roles.facilitator)}
+                            onClick={() => {
+                              void callHub(async (client) => {
+                                await client.removeUser(user.id)
+                              })
+                            }}
+                            size="small"
+                            sx={{ mr: 0.5 }}
+                          >
+                            <RemoveUserIcon fontSize="small" />
+                          </IconButton>
+                        </span>
                       </Tooltip>
                     ) : null}
                     {user.name}
@@ -802,13 +813,17 @@ export function RoomPage() {
       />
 
       <VotingOptionsDialog
+        currentFacilitatorCanVote={facilitatorCanVote}
         currentVoteOptions={roomState?.voteOptions}
         currentVotingMode={roomState?.votingMode}
         onCancel={() => setShowVotingOptionsDialog(false)}
-        onSave={(nextVoteOptions, nextVotingMode) => {
+        onSave={(nextVoteOptions, nextVotingMode, nextFacilitatorCanVote) => {
           setShowVotingOptionsDialog(false)
           setStoredVoteOptions(nextVoteOptions)
-          const update: RoomOptions = { voteOptions: nextVoteOptions }
+          const update: RoomOptions = {
+            voteOptions: nextVoteOptions,
+            facilitatorCanVote: nextFacilitatorCanVote,
+          }
           if (nextVotingMode !== undefined) {
             update.votingMode = nextVotingMode
           }

--- a/PointerStar/ClientApp/src/types/contracts.ts
+++ b/PointerStar/ClientApp/src/types/contracts.ts
@@ -20,6 +20,7 @@ export interface User {
 
 export interface RoomState {
   autoShowVotes: boolean
+  facilitatorCanVote: boolean
   resetVotesRequestedAt?: string | null
   resetVotesRequestedBy?: string | null
   roomId: string
@@ -32,6 +33,7 @@ export interface RoomState {
 
 export interface RoomOptions {
   autoShowVotes?: boolean
+  facilitatorCanVote?: boolean
   voteOptions?: string[]
   votesShown?: boolean
   votingMode?: VotingMode

--- a/PointerStar/Server/Room/InMemoryRoomManager.cs
+++ b/PointerStar/Server/Room/InMemoryRoomManager.cs
@@ -169,6 +169,11 @@ public class InMemoryRoomManager : IRoomManager
                     room = room with { AutoShowVotes = autoShowVotes };
                 }
 
+                if (roomOptions.FacilitatorCanVote is { } facilitatorCanVote)
+                {
+                    room = room with { FacilitatorCanVote = facilitatorCanVote };
+                }
+
                 if (roomOptions.VotesShown is { } votesShown)
                 {
                     room = room with { VotesShown = votesShown };
@@ -358,6 +363,11 @@ public class InMemoryRoomManager : IRoomManager
             {
                 return room;
             }
+            // Facilitators cannot be demoted to observer
+            if (room.Users.SingleOrDefault(u => u.Id == userId)?.Role == Role.Facilitator)
+            {
+                return room;
+            }
             return room with
             {
                 Users = [.. room.Users.Select(u => u.Id == userId ? u with
@@ -451,8 +461,10 @@ public class InMemoryRoomManager : IRoomManager
     {
         if (roomState.AutoShowVotes)
         {
-            var teamMembers = roomState.TeamMembers;
-            if (teamMembers.Any() && teamMembers.All(x => x.Vote is not null))
+            IReadOnlyList<User> votingMembers = roomState.FacilitatorCanVote
+                ? [.. roomState.TeamMembers, .. roomState.Facilitators]
+                : roomState.TeamMembers;
+            if (votingMembers.Any() && votingMembers.All(x => x.Vote is not null))
             {
                 return true;
             }

--- a/PointerStar/Shared/RoomOptions.cs
+++ b/PointerStar/Shared/RoomOptions.cs
@@ -4,6 +4,7 @@ public record class RoomOptions
 {
     public bool? VotesShown { get; init; }
     public bool? AutoShowVotes { get; init; }
+    public bool? FacilitatorCanVote { get; init; }
     public string[]? VoteOptions { get; init; }
     public VotingMode? VotingMode { get; init; }
 }

--- a/PointerStar/Shared/RoomState.cs
+++ b/PointerStar/Shared/RoomState.cs
@@ -13,6 +13,7 @@ public sealed record class RoomState(string RoomId, User[] Users)
 
     public bool VotesShown { get; init; }
     public bool AutoShowVotes { get; init; }
+    public bool FacilitatorCanVote { get; init; }
 
     public string[] VoteOptions { get; init; } = VotingPresets.Fibonacci;
     public DateTime? VoteStartTime { get; init; } = DateTime.UtcNow;


### PR DESCRIPTION
## Why

In some pointing poker sessions, the facilitator wants to participate as a voter too. Previously, facilitators had no way to cast votes -- they were always in a separate observer-like role. This adds a room setting to allow facilitators to vote alongside their team members.

## What changed

A new "Allow facilitator to vote" checkbox in the Configure Options dialog controls the feature. When enabled:

- The "Preview votes" switch is hidden (it conflicts with the facilitator also being a voter).
- The facilitator appears in both the **Team Members** card (as a voting participant) and the **Facilitators** card.
- The move-to-observer button in the Team Members card is disabled for facilitators (with a tooltip explaining why).
- Vote results, percentages, and the Giphy vote display all account for facilitator votes.

**Backend changes:**
- `RoomState.FacilitatorCanVote` bool property (default `false`) persisted and broadcast via SignalR.
- `InMemoryRoomManager.UpdateRoomAsync` applies the new setting.
- `ShouldShowVotes` counts facilitator votes when the option is on, so auto-reveal works correctly.
- `RemoveUserAsync` now guards against demoting a facilitator to observer server-side, even if the client button is bypassed.

**Frontend changes:**
- `VotingOptionsDialog` gains a `currentFacilitatorCanVote` prop and the `onSave` callback passes the new value back.
- `RoomPage` derives a `votingMembers` memo (team members + facilitators when enabled) and uses it consistently for the Team Members card, grouped vote results, percentages, and Giphy display.