### PR TITLE
Improve responsive UX for home and room experiences

### DIFF
--- a/PointerStar/ClientApp/src/components/AppLayout.tsx
+++ b/PointerStar/ClientApp/src/components/AppLayout.tsx
@@ -3,6 +3,7 @@ import {
   AppBar,
   Box,
   IconButton,
+  Stack,
   Toolbar,
   Tooltip,
   Typography,
@@ -12,9 +13,11 @@ import {
   DarkMode as DarkModeIcon,
   LightMode as LightModeIcon,
 } from '@mui/icons-material'
+import { Link as RouterLink } from 'react-router-dom'
 
 import { CookieConsentBanner } from './CookieConsentBanner'
 import type { ThemePreference } from '../hooks/useThemePreference'
+import { useCookieConsent } from '../hooks/useCookieConsent'
 
 interface AppLayoutProps {
   appVersion?: string | null
@@ -51,6 +54,9 @@ export function AppLayout({
   onCycleTheme,
   themePreference,
 }: AppLayoutProps) {
+  const consent = useCookieConsent()
+  const hasConsentBanner = !consent.hasUserResponded
+
   return (
     <Box
       sx={(theme) => ({
@@ -68,13 +74,35 @@ export function AppLayout({
           borderBottom: `1px solid ${theme.palette.divider}`,
         })}
       >
-        <Toolbar>
-          <Typography sx={{ ml: 1 }} variant="h5">
-            Pointer*
-          </Typography>
+        <Toolbar sx={{ gap: 1 }}>
+          <RouterLink
+            style={{
+              alignItems: 'center',
+              color: 'inherit',
+              display: 'inline-flex',
+              textDecoration: 'none',
+            }}
+            to="/"
+          >
+            <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+              <img
+                alt="Pointer* logo"
+                src={`${import.meta.env.BASE_URL}favicon.svg`}
+                style={{
+                  borderRadius: 4,
+                  display: 'block',
+                  height: 28,
+                  width: 28,
+                }}
+              />
+              <Typography sx={{ fontWeight: 700 }} variant="h6">
+                Pointer*
+              </Typography>
+            </Stack>
+          </RouterLink>
           <Box sx={{ flexGrow: 1 }} />
           <Tooltip title={getThemeTooltip(themePreference)}>
-            <IconButton color="inherit" onClick={onCycleTheme}>
+            <IconButton aria-label={getThemeTooltip(themePreference)} color="inherit" onClick={onCycleTheme}>
               {getThemeIcon(themePreference)}
             </IconButton>
           </Tooltip>
@@ -92,7 +120,14 @@ export function AppLayout({
           ) : null}
         </Toolbar>
       </AppBar>
-      <Box component="main" sx={{ backgroundColor: 'background.default', flexGrow: 1, pb: 12 }}>
+      <Box
+        component="main"
+        sx={{
+          backgroundColor: 'background.default',
+          flexGrow: 1,
+          pb: hasConsentBanner ? { md: 12, xs: 'calc(9rem + env(safe-area-inset-bottom))' } : { md: 6, xs: 4 },
+        }}
+      >
         {children}
       </Box>
       <CookieConsentBanner />

--- a/PointerStar/ClientApp/src/components/CookieConsentBanner.tsx
+++ b/PointerStar/ClientApp/src/components/CookieConsentBanner.tsx
@@ -17,7 +17,9 @@ export function CookieConsentBanner() {
         borderTop: `1px solid ${theme.palette.divider}`,
         bottom: 0,
         left: 0,
-        padding: 2,
+        pb: 'max(1rem, env(safe-area-inset-bottom))',
+        pt: 2,
+        px: 2,
         position: 'fixed',
         right: 0,
         width: '100%',
@@ -42,11 +44,16 @@ export function CookieConsentBanner() {
               &quot;Accept&quot;, you consent to the use of cookies.
             </Typography>
           </Box>
-          <Stack direction="row" spacing={2}>
-            <Button color="inherit" onClick={consent.reject} variant="outlined">
+          <Stack direction={{ sm: 'row', xs: 'column-reverse' }} spacing={1.5} sx={{ minWidth: { sm: 196, xs: '100%' } }}>
+            <Button
+              color="inherit"
+              onClick={consent.reject}
+              sx={{ minHeight: 44, width: { sm: 'auto', xs: '100%' } }}
+              variant="outlined"
+            >
               Reject
             </Button>
-            <Button onClick={consent.accept} variant="contained">
+            <Button onClick={consent.accept} sx={{ minHeight: 44, width: { sm: 'auto', xs: '100%' } }} variant="contained">
               Accept
             </Button>
           </Stack>

--- a/PointerStar/ClientApp/src/components/GiphyVotingPanel.tsx
+++ b/PointerStar/ClientApp/src/components/GiphyVotingPanel.tsx
@@ -11,6 +11,8 @@ import {
   Paper,
   TextField,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 import SearchIcon from '@mui/icons-material/Search'
@@ -28,6 +30,10 @@ interface GiphyVotingPanelProps {
  * Searches are debounced to avoid API calls on every keystroke.
  */
 export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({ currentVote, onVoteSubmit }) => {
+  const theme = useTheme()
+  const isSmUp = useMediaQuery(theme.breakpoints.up('sm'))
+  const isMdUp = useMediaQuery(theme.breakpoints.up('md'))
+
   const [searchQuery, setSearchQuery] = useState('')
   const [results, setResults] = useState<GiphyItem[]>([])
   const [loading, setLoading] = useState(false)
@@ -163,6 +169,8 @@ export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({ currentVote,
     void handleSearch(activeQuery, nextOffset, true)
   }, [activeQuery, handleSearch, hasMoreResults, loading, loadingMore, nextOffset])
 
+  const giphyColumns = isMdUp ? 4 : isSmUp ? 3 : 2
+
   return (
     <Box>
       {!isSearchExpanded ? (
@@ -222,11 +230,24 @@ export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({ currentVote,
 
           {!loading && results.length > 0 && (
             <Paper sx={{ padding: 1 }}>
-              <ImageList variant="masonry" cols={3} gap={8}>
+              <ImageList cols={giphyColumns} gap={8} variant="masonry">
                 {results.map((gif) => (
                   <ImageListItem
+                    aria-label={`Select GIF: ${gif.title}`}
+                    aria-pressed={selectedId === gif.id}
                     key={gif.id}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault()
+                        handleSelectGif(gif.id)
+                      }
+                    }}
                     sx={{
+                      '&:focus-visible': {
+                        outline: '2px solid',
+                        outlineColor: 'primary.main',
+                        outlineOffset: 2,
+                      },
                       cursor: 'pointer',
                       opacity: selectedId === gif.id ? 1 : 0.8,
                       border: selectedId === gif.id ? '3px solid' : '1px solid',
@@ -239,6 +260,8 @@ export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({ currentVote,
                       },
                     }}
                     onClick={() => handleSelectGif(gif.id)}
+                    role="button"
+                    tabIndex={0}
                   >
                     <img
                       src={gif.imageUrl}

--- a/PointerStar/ClientApp/src/components/UserDialog.tsx
+++ b/PointerStar/ClientApp/src/components/UserDialog.tsx
@@ -10,6 +10,8 @@ import {
   Stack,
   TextField,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material'
 
 import { getNewUserRole } from '../services/roomApi'
@@ -32,6 +34,9 @@ export function UserDialog({
   open,
   roomId,
 }: UserDialogProps) {
+  const theme = useTheme()
+  const useConnectedRoleButtons = useMediaQuery(theme.breakpoints.up('sm'))
+
   const [name, setName] = useState(defaultName ?? '')
   const [selectedRoleId, setSelectedRoleId] = useState<string | null>(defaultRoleId ?? null)
   const [isLoading, setIsLoading] = useState(false)
@@ -91,31 +96,69 @@ export function UserDialog({
               value={name}
               variant="standard"
             />
-            <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
-              <Typography>I want to...</Typography>
-              <ButtonGroup>
-                <Button
-                  disabled={isLoading}
-                  onClick={() => setSelectedRoleId(roles.teamMember.id)}
-                  variant={selectedRoleId === roles.teamMember.id ? 'contained' : 'outlined'}
-                >
-                  Vote
-                </Button>
-                <Button
-                  disabled={isLoading}
-                  onClick={() => setSelectedRoleId(roles.facilitator.id)}
-                  variant={selectedRoleId === roles.facilitator.id ? 'contained' : 'outlined'}
-                >
-                  Facilitate
-                </Button>
-                <Button
-                  disabled={isLoading}
-                  onClick={() => setSelectedRoleId(roles.observer.id)}
-                  variant={selectedRoleId === roles.observer.id ? 'contained' : 'outlined'}
-                >
-                  Observe
-                </Button>
-              </ButtonGroup>
+            <Stack direction={{ sm: 'row', xs: 'column' }} spacing={2} sx={{ alignItems: { sm: 'center', xs: 'stretch' } }}>
+              <Typography sx={{ minWidth: 84 }}>I want to...</Typography>
+              {useConnectedRoleButtons ? (
+                <ButtonGroup>
+                  <Button
+                    disabled={isLoading}
+                    onClick={() => setSelectedRoleId(roles.teamMember.id)}
+                    sx={{ minHeight: 44 }}
+                    type="button"
+                    variant={selectedRoleId === roles.teamMember.id ? 'contained' : 'outlined'}
+                  >
+                    Vote
+                  </Button>
+                  <Button
+                    disabled={isLoading}
+                    onClick={() => setSelectedRoleId(roles.facilitator.id)}
+                    sx={{ minHeight: 44 }}
+                    type="button"
+                    variant={selectedRoleId === roles.facilitator.id ? 'contained' : 'outlined'}
+                  >
+                    Facilitate
+                  </Button>
+                  <Button
+                    disabled={isLoading}
+                    onClick={() => setSelectedRoleId(roles.observer.id)}
+                    sx={{ minHeight: 44 }}
+                    type="button"
+                    variant={selectedRoleId === roles.observer.id ? 'contained' : 'outlined'}
+                  >
+                    Observe
+                  </Button>
+                </ButtonGroup>
+              ) : (
+                <Stack direction={{ sm: 'row', xs: 'column' }} spacing={1} sx={{ flexGrow: 1 }}>
+                  <Button
+                    disabled={isLoading}
+                    onClick={() => setSelectedRoleId(roles.teamMember.id)}
+                    sx={{ minHeight: 44 }}
+                    type="button"
+                    variant={selectedRoleId === roles.teamMember.id ? 'contained' : 'outlined'}
+                  >
+                    Vote
+                  </Button>
+                  <Button
+                    disabled={isLoading}
+                    onClick={() => setSelectedRoleId(roles.facilitator.id)}
+                    sx={{ minHeight: 44 }}
+                    type="button"
+                    variant={selectedRoleId === roles.facilitator.id ? 'contained' : 'outlined'}
+                  >
+                    Facilitate
+                  </Button>
+                  <Button
+                    disabled={isLoading}
+                    onClick={() => setSelectedRoleId(roles.observer.id)}
+                    sx={{ minHeight: 44 }}
+                    type="button"
+                    variant={selectedRoleId === roles.observer.id ? 'contained' : 'outlined'}
+                  >
+                    Observe
+                  </Button>
+                </Stack>
+              )}
               {isLoading ? <CircularProgress size={18} /> : null}
             </Stack>
           </Stack>

--- a/PointerStar/ClientApp/src/components/VotingOptionsDialog.tsx
+++ b/PointerStar/ClientApp/src/components/VotingOptionsDialog.tsx
@@ -123,8 +123,13 @@ export function VotingOptionsDialog({
                 <Typography variant="body2">Or customize your options:</Typography>
                 <Stack spacing={1}>
                   {voteOptions.map((option, index) => (
-                    <Stack direction="row" key={`${option}-${index}`} spacing={1} sx={{ alignItems: 'center' }}>
-                      <Stack spacing={0}>
+                    <Stack
+                      direction={{ sm: 'row', xs: 'column' }}
+                      key={`${option}-${index}`}
+                      spacing={1}
+                      sx={{ alignItems: { sm: 'center', xs: 'stretch' } }}
+                    >
+                      <Stack direction="row" spacing={0.5}>
                         <IconButton
                           disabled={index === 0}
                           onClick={() =>
@@ -151,6 +156,16 @@ export function VotingOptionsDialog({
                         >
                           <ArrowDownwardIcon fontSize="small" />
                         </IconButton>
+                        <IconButton
+                          color="error"
+                          disabled={voteOptions.length <= 1}
+                          onClick={() =>
+                            setVoteOptions((current) => current.filter((_, currentIndex) => currentIndex !== index))
+                          }
+                          size="small"
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
                       </Stack>
                       <TextField
                         fullWidth
@@ -166,16 +181,6 @@ export function VotingOptionsDialog({
                         value={option}
                         variant="outlined"
                       />
-                      <IconButton
-                        color="error"
-                        disabled={voteOptions.length <= 1}
-                        onClick={() =>
-                          setVoteOptions((current) => current.filter((_, currentIndex) => currentIndex !== index))
-                        }
-                        size="small"
-                      >
-                        <DeleteIcon fontSize="small" />
-                      </IconButton>
                     </Stack>
                   ))}
                 </Stack>

--- a/PointerStar/ClientApp/src/pages/HomePage.tsx
+++ b/PointerStar/ClientApp/src/pages/HomePage.tsx
@@ -5,11 +5,13 @@ import {
   Button,
   Card,
   CardContent,
+  CardHeader,
   Container,
   Divider,
   IconButton,
   Snackbar,
   Stack,
+  TextField,
   Typography,
 } from '@mui/material'
 import { Delete as DeleteIcon } from '@mui/icons-material'
@@ -55,34 +57,106 @@ export function HomePage({ notFound = false }: HomePageProps) {
   const navigate = useNavigate()
   const [recentRooms, setRecentRooms] = useState<RecentRoom[]>([])
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [roomCode, setRoomCode] = useState('')
 
   useEffect(() => {
     setRecentRooms(getRecentRooms())
   }, [])
 
+  const openRoom = (roomId: string) => {
+    const normalizedRoomId = roomId.trim()
+    if (!normalizedRoomId) {
+      return
+    }
+
+    navigate(`/room/${encodeURIComponent(normalizedRoomId)}`)
+  }
+
   return (
-    <Container maxWidth="md" sx={{ mt: 8 }}>
+    <Container maxWidth="md" sx={{ mt: { md: 8, xs: 4 } }}>
       <Stack spacing={4}>
+        <Stack spacing={1} sx={{ alignItems: 'center', justifyContent: 'center' }}>
+          <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+            <img
+              alt="Pointer* logo"
+              src={`${import.meta.env.BASE_URL}favicon.svg`}
+              style={{
+                borderRadius: 6,
+                display: 'block',
+                height: 40,
+                width: 40,
+              }}
+            />
+            <Typography component="h1" variant="h4">
+              Pointer*
+            </Typography>
+          </Stack>
+          <Typography align="center" color="text.secondary" sx={{ maxWidth: 560 }} variant="body1">
+            Run fast, focused estimation sessions with your team from any device.
+          </Typography>
+        </Stack>
+
         <Stack sx={{ alignItems: 'center', justifyContent: 'center' }}>
           {notFound ? (
             <Typography align="center" variant="h5">
               Sorry, there&apos;s nothing at this address.
             </Typography>
           ) : (
-            <Button
-              onClick={() => {
-                void generateRoomId()
-                  .then((roomId) => navigate(`/room/${roomId}`))
-                  .catch((error) => {
-                    console.error('Unable to create a room.', error)
-                    setErrorMessage('Unable to create a room right now.')
-                  })
-              }}
-              size="large"
-              variant="contained"
-            >
-              Create New Room
-            </Button>
+            <Card sx={{ width: '100%' }}>
+              <CardHeader title="Start or join a room" />
+              <CardContent>
+                <Stack spacing={2.5}>
+                  <Button
+                    onClick={() => {
+                      void generateRoomId()
+                        .then((roomId) => openRoom(roomId))
+                        .catch((error) => {
+                          console.error('Unable to create a room.', error)
+                          setErrorMessage('Unable to create a room right now.')
+                        })
+                    }}
+                    size="large"
+                    sx={{ minHeight: 56, width: { md: 'fit-content', xs: '100%' } }}
+                    variant="contained"
+                  >
+                    Create New Room
+                  </Button>
+
+                  <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                    <Divider sx={{ flexGrow: 1 }} />
+                    <Typography color="text.secondary" sx={{ px: 1 }} variant="body2">
+                      or
+                    </Typography>
+                    <Divider sx={{ flexGrow: 1 }} />
+                  </Stack>
+
+                  <Stack direction={{ sm: 'row', xs: 'column' }} spacing={1.5}>
+                    <TextField
+                      fullWidth
+                      label="Room code"
+                      onChange={(event) => setRoomCode(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                          event.preventDefault()
+                          openRoom(roomCode)
+                        }
+                      }}
+                      placeholder="Enter room code"
+                      value={roomCode}
+                    />
+                    <Button
+                      disabled={!roomCode.trim()}
+                      onClick={() => openRoom(roomCode)}
+                      size="large"
+                      sx={{ minHeight: 56, minWidth: { sm: 130 }, width: { sm: 'auto', xs: '100%' } }}
+                      variant="outlined"
+                    >
+                      Join Room
+                    </Button>
+                  </Stack>
+                </Stack>
+              </CardContent>
+            </Card>
           )}
         </Stack>
 
@@ -111,7 +185,7 @@ export function HomePage({ notFound = false }: HomePageProps) {
                         </Typography>
                       </Stack>
                       <Stack direction="row" spacing={2}>
-                        <Button onClick={() => navigate(`/room/${room.roomId}`)} size="small" variant="contained">
+                        <Button onClick={() => openRoom(room.roomId)} size="small" variant="contained">
                           Open
                         </Button>
                         <IconButton

--- a/PointerStar/ClientApp/src/pages/RoomPage.tsx
+++ b/PointerStar/ClientApp/src/pages/RoomPage.tsx
@@ -11,6 +11,10 @@ import {
   Container,
   FormControlLabel,
   IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
   Paper,
   Snackbar,
   Stack,
@@ -24,6 +28,7 @@ import {
   Edit as EditIcon,
   ExpandLess as ExpandLessIcon,
   ExpandMore as ExpandMoreIcon,
+  MoreVert as MoreVertIcon,
   PersonRemove as RemoveUserIcon,
   Refresh as RefreshIcon,
   Settings as SettingsIcon,
@@ -86,6 +91,8 @@ export function RoomPage() {
   const [resetVotesRequestedBy, setResetVotesRequestedBy] = useState<string | null>(null)
   const [serverClockOffsetMs, setServerClockOffsetMs] = useState(0)
   const [showQrCode, setShowQrCode] = useState(false)
+  const [showAdvancedFacilitatorControls, setShowAdvancedFacilitatorControls] = useState(false)
+  const [mobileActionsAnchorEl, setMobileActionsAnchorEl] = useState<HTMLElement | null>(null)
   const [showUserDialog, setShowUserDialog] = useState(false)
   const [showVotingOptionsDialog, setShowVotingOptionsDialog] = useState(false)
   const [timerTick, setTimerTick] = useState(0)
@@ -176,6 +183,7 @@ export function RoomPage() {
     () => groupedVotes.reduce((max, entry) => Math.max(max, entry.count), 0),
     [groupedVotes],
   )
+  const isMobileActionsOpen = Boolean(mobileActionsAnchorEl)
 
   const showSnackbar = useCallback((message: string, severity: AlertColor = 'success') => {
     setSnackbar({
@@ -436,23 +444,41 @@ export function RoomPage() {
             p: theme.palette.mode === 'dark' ? 1.5 : 0,
           })}
         >
-          <Button
-            color="inherit"
-            onClick={() => {
-              void navigator.clipboard
-                .writeText(window.location.href)
-                .then(() => showSnackbar('Link Copied'))
-                .catch((error) => {
-                  console.error('Unable to copy the invitation link.', error)
-                  showSnackbar('Unable to copy the invitation link.', 'error')
-                })
-            }}
-            startIcon={<CopyIcon />}
-            variant="outlined"
+          <Stack
+            direction="row"
+            spacing={1}
+            sx={{ alignItems: 'center', flexGrow: { md: 0, xs: 1 }, width: { md: 'auto', xs: '100%' } }}
           >
-            Copy Invitation URL
-          </Button>
-          <Stack>
+            <Button
+              color="primary"
+              onClick={() => {
+                void navigator.clipboard
+                  .writeText(window.location.href)
+                  .then(() => showSnackbar('Link Copied'))
+                  .catch((error) => {
+                    console.error('Unable to copy the invitation link.', error)
+                    showSnackbar('Unable to copy the invitation link.', 'error')
+                  })
+              }}
+              startIcon={<CopyIcon />}
+              sx={{ flexGrow: { md: 0, xs: 1 }, minHeight: 48 }}
+              variant="contained"
+            >
+              Copy Invitation URL
+            </Button>
+            <IconButton
+              aria-controls={isMobileActionsOpen ? 'room-mobile-actions-menu' : undefined}
+              aria-expanded={isMobileActionsOpen ? 'true' : undefined}
+              aria-haspopup="menu"
+              aria-label="Open room actions"
+              onClick={(event) => setMobileActionsAnchorEl(event.currentTarget)}
+              sx={{ display: { md: 'none', xs: 'inline-flex' } }}
+            >
+              <MoreVertIcon />
+            </IconButton>
+          </Stack>
+
+          <Box sx={{ display: { md: 'inline-flex', xs: 'none' }, gap: 1 }}>
             <Button
               color="inherit"
               onClick={() => setShowQrCode((current) => !current)}
@@ -461,30 +487,55 @@ export function RoomPage() {
             >
               {showQrCode ? 'Hide' : 'Show'} QR Code
             </Button>
-            <Collapse in={showQrCode}>
-              <Box
-                sx={(theme) => ({
-                  backgroundColor: '#ffffff',
-                  border: `2px solid ${theme.palette.divider}`,
-                  borderRadius: 1,
-                  display: 'inline-flex',
-                  mt: 1,
-                  p: 1,
-                })}
-              >
-                <QRCodeSVG value={window.location.href} />
-              </Box>
-            </Collapse>
-          </Stack>
-          <Button
-            color="inherit"
-            onClick={() => setShowUserDialog(true)}
-            startIcon={<EditIcon />}
-            variant="outlined"
+            <Button color="inherit" onClick={() => setShowUserDialog(true)} startIcon={<EditIcon />} variant="outlined">
+              {name || currentUser?.name || 'Edit user'}
+            </Button>
+          </Box>
+
+          <Menu
+            anchorEl={mobileActionsAnchorEl}
+            id="room-mobile-actions-menu"
+            onClose={() => setMobileActionsAnchorEl(null)}
+            open={isMobileActionsOpen}
           >
-            {name || currentUser?.name || 'Edit user'}
-          </Button>
+            <MenuItem
+              onClick={() => {
+                setShowQrCode((current) => !current)
+                setMobileActionsAnchorEl(null)
+              }}
+            >
+              <ListItemIcon>{showQrCode ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}</ListItemIcon>
+              <ListItemText>{showQrCode ? 'Hide' : 'Show'} QR Code</ListItemText>
+            </MenuItem>
+            <MenuItem
+              onClick={() => {
+                setShowUserDialog(true)
+                setMobileActionsAnchorEl(null)
+              }}
+            >
+              <ListItemIcon>
+                <EditIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>{name || currentUser?.name || 'Edit user'}</ListItemText>
+            </MenuItem>
+          </Menu>
         </Paper>
+
+        <Collapse in={showQrCode}>
+          <Box
+            sx={(theme) => ({
+              alignItems: 'center',
+              backgroundColor: '#ffffff',
+              border: `2px solid ${theme.palette.divider}`,
+              borderRadius: 1,
+              display: 'inline-flex',
+              maxWidth: '100%',
+              p: 1,
+            })}
+          >
+            <QRCodeSVG value={window.location.href} />
+          </Box>
+        </Collapse>
 
         {voteStartTime ? (
           <Typography>
@@ -547,17 +598,23 @@ export function RoomPage() {
                 }}
               />
             ) : (
-              <Box sx={{ display: 'flex', flexWrap: 'wrap' }}>
-                {(roomState?.voteOptions ?? defaultVoteOptions).map((option) => (
+              <Box
+                sx={{
+                  display: 'grid',
+                  gap: 1,
+                  gridTemplateColumns: { md: 'repeat(8, minmax(0, 1fr))', sm: 'repeat(6, minmax(0, 1fr))', xs: 'repeat(4, minmax(0, 1fr))' },
+                }}
+              >
+                {(roomState?.voteOptions ?? defaultVoteOptions).map((option, index) => (
                   <Button
                     color={option === currentUser?.vote ? 'success' : 'primary'}
-                    key={option}
+                    key={`${option}-${index}`}
                     onClick={() => {
                       void callHub(async (client) => {
                         await client.submitVote(option)
                       })
                     }}
-                    sx={{ height: 70, m: 0.5, minWidth: 70, px: 2.5 }}
+                    sx={{ fontSize: { sm: '1rem', xs: '0.95rem' }, height: { sm: 66, xs: 56 }, minWidth: 0 }}
                     variant="contained"
                   >
                     {option}
@@ -569,53 +626,76 @@ export function RoomPage() {
         ) : null}
 
         {isRole(currentUser, roles.facilitator) ? (
-          <Stack direction={{ md: 'row', xs: 'column' }} spacing={2}>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={votesShown}
-                  color="success"
-                  onChange={(event) => {
-                    const checked = event.target.checked
-                    setVotesShown(checked)
-                    void requestRoomUpdate({ votesShown: checked })
-                  }}
+          <Stack spacing={1.5}>
+            <Stack direction={{ md: 'row', xs: 'column' }} spacing={2}>
+              <Button
+                color={votesShown ? 'success' : 'primary'}
+                onClick={() => {
+                  const checked = !votesShown
+                  setVotesShown(checked)
+                  void requestRoomUpdate({ votesShown: checked })
+                }}
+                sx={{ width: { md: 'auto', xs: '100%' } }}
+                variant={votesShown ? 'contained' : 'outlined'}
+              >
+                {votesShown ? 'Hide Votes' : 'Show Votes'}
+              </Button>
+              <Button
+                color="warning"
+                onClick={() => void handleResetVotes()}
+                sx={{ width: { md: 'auto', xs: '100%' } }}
+                variant="contained"
+              >
+                Reset Votes
+              </Button>
+              <Button
+                endIcon={showAdvancedFacilitatorControls ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                onClick={() => setShowAdvancedFacilitatorControls((current) => !current)}
+                sx={{ width: { md: 'auto', xs: '100%' } }}
+                variant="text"
+              >
+                Advanced
+              </Button>
+            </Stack>
+
+            <Collapse in={showAdvancedFacilitatorControls} unmountOnExit>
+              <Stack direction={{ md: 'row', xs: 'column' }} spacing={2}>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={autoShowVotes}
+                      color="info"
+                      onChange={(event) => {
+                        const checked = event.target.checked
+                        setAutoShowVotes(checked)
+                        void requestRoomUpdate({ autoShowVotes: checked })
+                      }}
+                    />
+                  }
+                  label="Automatically reveal votes"
                 />
-              }
-              label="Show votes"
-            />
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={autoShowVotes}
-                  color="info"
-                  onChange={(event) => {
-                    const checked = event.target.checked
-                    setAutoShowVotes(checked)
-                    void requestRoomUpdate({ autoShowVotes: checked })
-                  }}
-                />
-              }
-              label="Automatically reveal votes"
-            />
-            {!facilitatorCanVote ? (
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={previewVotes}
-                    color="info"
-                    onChange={(event) => setPreviewVotes(event.target.checked)}
+                {!facilitatorCanVote ? (
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={previewVotes}
+                        color="info"
+                        onChange={(event) => setPreviewVotes(event.target.checked)}
+                      />
+                    }
+                    label="Preview votes"
                   />
-                }
-                label="Preview votes"
-              />
-            ) : null}
-            <Button color="warning" onClick={() => void handleResetVotes()} variant="contained">
-              Reset Votes
-            </Button>
-            <Button onClick={() => setShowVotingOptionsDialog(true)} startIcon={<SettingsIcon />} variant="outlined">
-              Configure Options
-            </Button>
+                ) : null}
+                <Button
+                  onClick={() => setShowVotingOptionsDialog(true)}
+                  startIcon={<SettingsIcon />}
+                  sx={{ width: { md: 'auto', xs: '100%' } }}
+                  variant="outlined"
+                >
+                  Configure Options
+                </Button>
+              </Stack>
+            </Collapse>
           </Stack>
         ) : null}
 


### PR DESCRIPTION
This improves day-to-day usability across mobile and desktop, with a focus on reducing clunky room controls and making app branding visible in the product UI.

### What changed
- Added visible logo and wordmark in the app layout, and adjusted main content spacing to better coexist with the cookie banner and safe-area insets.
- Reworked the home page actions so creating and joining rooms are visually separated, clearer on wide screens, and easier to use on narrow screens.
- Refined room page top actions for responsive behavior: copy invitation remains prominent, mobile overflow actions are cleaner, and the narrow-screen layout keeps copy + overflow inline.
- Simplified facilitator controls by keeping primary actions in view and moving secondary controls into an Advanced section.
- Replaced the show/hide votes switch with a toggle-style button for clearer intent.
- Preserved familiar desktop behavior where requested, including connected role selection buttons on larger screens while keeping mobile-friendly controls.
- Improved dialog/panel responsiveness and interaction polish in voting options, user role selection, GIF voting, and cookie consent controls.

### Notes for reviewers
- This is primarily a UX and layout refactor in the React client; backend contracts and SignalR behavior are unchanged.
- Please pay extra attention to breakpoint transitions (`xs/sm/md`) on Home and Room pages, since most behavioral differences are responsive-state driven.