### PR TITLE
Default theme preference to dark mode

### DIFF
--- a/PointerStar/ClientApp/src/hooks/useThemePreference.ts
+++ b/PointerStar/ClientApp/src/hooks/useThemePreference.ts
@@ -6,11 +6,11 @@ import { getStoredThemePreferenceValue, setStoredThemePreferenceValue } from '..
 export type ThemePreference = 'system' | 'light' | 'dark'
 
 function parseThemePreference(value: string): ThemePreference {
-  if (value === 'light' || value === 'dark') {
+  if (value === 'light' || value === 'dark' || value === 'system') {
     return value
   }
 
-  return 'system'
+  return 'dark'
 }
 
 export function useThemePreference() {


### PR DESCRIPTION
## Summary
The app currently falls back to `system` when no saved theme preference exists, which can start new sessions in light mode. This updates the default so first-time users land in dark mode.

## Approach
- Updated `parseThemePreference` in `useThemePreference` to treat `system`, `light`, and `dark` as valid stored values.
- Changed the fallback for missing or invalid values from `system` to `dark`.

## Notes
This is a targeted behavior change to the default only; explicit saved preferences continue to work as before.