### PR TITLE
Center Create New Room button on Home page

### DIFF
--- a/PointerStar/ClientApp/src/pages/HomePage.tsx
+++ b/PointerStar/ClientApp/src/pages/HomePage.tsx
@@ -116,7 +116,12 @@ export function HomePage({ notFound = false }: HomePageProps) {
                         })
                     }}
                     size="large"
-                    sx={{ minHeight: 56, width: { md: 'fit-content', xs: '100%' } }}
+                    sx={{
+                      alignSelf: { md: 'center', xs: 'stretch' },
+                      justifyContent: 'center',
+                      minHeight: 56,
+                      width: { md: 'fit-content', xs: '100%' },
+                    }}
                     variant="contained"
                   >
                     Create New Room


### PR DESCRIPTION
## Why
The primary create-room action on the home page was not centered, which made the call to action feel visually off-balance.

## What changed
- Updated the `Create New Room` button styles in `HomePage.tsx` to center it on medium and larger screens.
- Kept mobile behavior unchanged by preserving full-width layout on small screens.
- Explicitly centered button content to keep the label aligned.

## Notes
- This is a UI-only layout adjustment scoped to the home page room creation control.