### PR TITLE
Make invitation copy control a split button

### DIFF
--- a/PointerStar/ClientApp/src/pages/RoomPage.tsx
+++ b/PointerStar/ClientApp/src/pages/RoomPage.tsx
@@ -4,6 +4,7 @@ import {
   Alert,
   Box,
   Button,
+  ButtonGroup,
   Card,
   CardContent,
   CardHeader,
@@ -24,6 +25,7 @@ import {
   type AlertColor,
 } from '@mui/material'
 import {
+  ArrowDropDown as ArrowDropDownIcon,
   ContentCopy as CopyIcon,
   Edit as EditIcon,
   ExpandLess as ExpandLessIcon,
@@ -91,6 +93,7 @@ export function RoomPage() {
   const [resetVotesRequestedBy, setResetVotesRequestedBy] = useState<string | null>(null)
   const [serverClockOffsetMs, setServerClockOffsetMs] = useState(0)
   const [showQrCode, setShowQrCode] = useState(false)
+  const [inviteActionsAnchorEl, setInviteActionsAnchorEl] = useState<HTMLElement | null>(null)
   const [showAdvancedFacilitatorControls, setShowAdvancedFacilitatorControls] = useState(false)
   const [mobileActionsAnchorEl, setMobileActionsAnchorEl] = useState<HTMLElement | null>(null)
   const [showUserDialog, setShowUserDialog] = useState(false)
@@ -183,6 +186,7 @@ export function RoomPage() {
     () => groupedVotes.reduce((max, entry) => Math.max(max, entry.count), 0),
     [groupedVotes],
   )
+  const isInviteActionsOpen = Boolean(inviteActionsAnchorEl)
   const isMobileActionsOpen = Boolean(mobileActionsAnchorEl)
 
   const showSnackbar = useCallback((message: string, severity: AlertColor = 'success') => {
@@ -192,6 +196,16 @@ export function RoomPage() {
       severity,
     })
   }, [])
+
+  const handleCopyInvitationUrl = useCallback(() => {
+    void navigator.clipboard
+      .writeText(window.location.href)
+      .then(() => showSnackbar('Link Copied'))
+      .catch((error) => {
+        console.error('Unable to copy the invitation link.', error)
+        showSnackbar('Unable to copy the invitation link.', 'error')
+      })
+  }, [showSnackbar])
 
   const callHub = useCallback(
     async <T,>(operation: (client: RoomHubClient) => Promise<T>) => {
@@ -449,23 +463,30 @@ export function RoomPage() {
             spacing={1}
             sx={{ alignItems: 'center', flexGrow: { md: 0, xs: 1 }, width: { md: 'auto', xs: '100%' } }}
           >
-            <Button
-              color="primary"
-              onClick={() => {
-                void navigator.clipboard
-                  .writeText(window.location.href)
-                  .then(() => showSnackbar('Link Copied'))
-                  .catch((error) => {
-                    console.error('Unable to copy the invitation link.', error)
-                    showSnackbar('Unable to copy the invitation link.', 'error')
-                  })
+            <ButtonGroup
+              sx={{
+                '& .MuiButton-root': {
+                  minHeight: 48,
+                },
+                flexGrow: { md: 0, xs: 1 },
               }}
-              startIcon={<CopyIcon />}
-              sx={{ flexGrow: { md: 0, xs: 1 }, minHeight: 48 }}
               variant="contained"
             >
-              Copy Invitation URL
-            </Button>
+              <Button color="primary" onClick={handleCopyInvitationUrl} startIcon={<CopyIcon />} sx={{ flexGrow: { md: 0, xs: 1 } }}>
+                Copy Invitation URL
+              </Button>
+              <Button
+                aria-controls={isInviteActionsOpen ? 'room-invite-actions-menu' : undefined}
+                aria-expanded={isInviteActionsOpen ? 'true' : undefined}
+                aria-haspopup="menu"
+                aria-label="Open invitation actions"
+                color="primary"
+                onClick={(event) => setInviteActionsAnchorEl(event.currentTarget)}
+                sx={{ minWidth: 48 }}
+              >
+                <ArrowDropDownIcon />
+              </Button>
+            </ButtonGroup>
             <IconButton
               aria-controls={isMobileActionsOpen ? 'room-mobile-actions-menu' : undefined}
               aria-expanded={isMobileActionsOpen ? 'true' : undefined}
@@ -479,18 +500,28 @@ export function RoomPage() {
           </Stack>
 
           <Box sx={{ display: { md: 'inline-flex', xs: 'none' }, gap: 1 }}>
-            <Button
-              color="inherit"
-              onClick={() => setShowQrCode((current) => !current)}
-              startIcon={showQrCode ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-              variant="text"
-            >
-              {showQrCode ? 'Hide' : 'Show'} QR Code
-            </Button>
             <Button color="inherit" onClick={() => setShowUserDialog(true)} startIcon={<EditIcon />} variant="outlined">
               {name || currentUser?.name || 'Edit user'}
             </Button>
           </Box>
+
+          <Menu
+            anchorEl={inviteActionsAnchorEl}
+            anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+            id="room-invite-actions-menu"
+            onClose={() => setInviteActionsAnchorEl(null)}
+            open={isInviteActionsOpen}
+            transformOrigin={{ horizontal: 'right', vertical: 'top' }}
+          >
+            <MenuItem
+              onClick={() => {
+                setShowQrCode((current) => !current)
+                setInviteActionsAnchorEl(null)
+              }}
+            >
+              <ListItemText>{showQrCode ? 'Hide' : 'Show'} QR Code</ListItemText>
+            </MenuItem>
+          </Menu>
 
           <Menu
             anchorEl={mobileActionsAnchorEl}
@@ -498,15 +529,6 @@ export function RoomPage() {
             onClose={() => setMobileActionsAnchorEl(null)}
             open={isMobileActionsOpen}
           >
-            <MenuItem
-              onClick={() => {
-                setShowQrCode((current) => !current)
-                setMobileActionsAnchorEl(null)
-              }}
-            >
-              <ListItemIcon>{showQrCode ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}</ListItemIcon>
-              <ListItemText>{showQrCode ? 'Hide' : 'Show'} QR Code</ListItemText>
-            </MenuItem>
             <MenuItem
               onClick={() => {
                 setShowUserDialog(true)


### PR DESCRIPTION
This updates the room invite controls so related actions are grouped under a single entry point. The goal is to keep the header actions cleaner while still making QR sharing easy to access.

### What changed
- Replaced the `Copy Invitation URL` button with a split button in `RoomPage`.
- Kept primary click behavior the same: copy the current room URL to clipboard.
- Moved the QR toggle into the split-button dropdown (`Show QR Code` / `Hide QR Code`).
- Removed the separate QR toggle from the desktop action row.
- Aligned the dropdown to the arrow trigger and set it to open left from that trigger.
- Removed the expand arrow icon from the QR menu item text row for a cleaner menu presentation.

### Notes
- Existing mobile overflow actions remain focused on user editing.
- No backend or contract changes were required; this is a UI-only adjustment in `PointerStar/ClientApp/src/pages/RoomPage.tsx`.