### PR TITLE
Bump fastify/github-action-merge-dependabot to v3.15.0

### DIFF
--- a/.github/workflows/main_pointerstar.yml
+++ b/.github/workflows/main_pointerstar.yml
@@ -100,7 +100,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3.14.0
+      - uses: fastify/github-action-merge-dependabot@v3.15.0
         with:
           use-github-auto-merge: true
           skip-verification: true


### PR DESCRIPTION
Updates the merge dependabot action to resolve build issues identified in the workflow.
