### PR TITLE
Persist favorite GIF section expansion state

### DIFF
--- a/PointerStar/ClientApp/src/components/GiphyVotingPanel.test.tsx
+++ b/PointerStar/ClientApp/src/components/GiphyVotingPanel.test.tsx
@@ -2,7 +2,12 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { GiphyVotingPanel } from './GiphyVotingPanel'
 import { GIPHY_PAGE_SIZE, searchGiphy } from '../services/giphyApi'
-import { getStoredFavoriteGifIds, setStoredFavoriteGifIds } from '../services/cookies'
+import {
+  getStoredFavoriteGifIds,
+  getStoredFavoriteGifsExpanded,
+  setStoredFavoriteGifIds,
+  setStoredFavoriteGifsExpanded,
+} from '../services/cookies'
 
 vi.mock('../services/giphyApi', () => ({
   GIPHY_PAGE_SIZE: 20,
@@ -11,12 +16,16 @@ vi.mock('../services/giphyApi', () => ({
 
 vi.mock('../services/cookies', () => ({
   getStoredFavoriteGifIds: vi.fn(() => []),
+  getStoredFavoriteGifsExpanded: vi.fn(() => true),
   setStoredFavoriteGifIds: vi.fn(),
+  setStoredFavoriteGifsExpanded: vi.fn(),
 }))
 
 const searchGiphyMock = vi.mocked(searchGiphy)
 const getStoredFavoriteGifIdsMock = vi.mocked(getStoredFavoriteGifIds)
+const getStoredFavoriteGifsExpandedMock = vi.mocked(getStoredFavoriteGifsExpanded)
 const setStoredFavoriteGifIdsMock = vi.mocked(setStoredFavoriteGifIds)
+const setStoredFavoriteGifsExpandedMock = vi.mocked(setStoredFavoriteGifsExpanded)
 
 const createGif = (index: number) => ({
   id: `gif-${index}`,
@@ -29,7 +38,10 @@ describe('GiphyVotingPanel', () => {
     searchGiphyMock.mockReset()
     getStoredFavoriteGifIdsMock.mockReset()
     getStoredFavoriteGifIdsMock.mockReturnValue([])
+    getStoredFavoriteGifsExpandedMock.mockReset()
+    getStoredFavoriteGifsExpandedMock.mockReturnValue(true)
     setStoredFavoriteGifIdsMock.mockReset()
+    setStoredFavoriteGifsExpandedMock.mockReset()
   })
 
   it('tracks the searched GIF query for recent chips', async () => {
@@ -161,12 +173,35 @@ describe('GiphyVotingPanel', () => {
     getStoredFavoriteGifIdsMock.mockReturnValue(['favorite-1'])
 
     render(<GiphyVotingPanel onVoteSubmit={vi.fn()} />)
+    const favoritesToggle = screen.getByRole('button', { name: 'Toggle favorite GIFs' })
 
     expect(screen.getByAltText('Favorite GIF favorite-1')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Hide' })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Hide' }))
-    expect(screen.getByRole('button', { name: 'Show' })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Show' }))
-    expect(screen.getByRole('button', { name: 'Hide' })).toBeInTheDocument()
+    expect(favoritesToggle).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.click(favoritesToggle)
+    expect(favoritesToggle).toHaveAttribute('aria-expanded', 'false')
+    fireEvent.click(favoritesToggle)
+    expect(favoritesToggle).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('starts collapsed when favorite GIF section expansion is stored as false', () => {
+    getStoredFavoriteGifIdsMock.mockReturnValue(['favorite-1'])
+    getStoredFavoriteGifsExpandedMock.mockReturnValue(false)
+
+    render(<GiphyVotingPanel onVoteSubmit={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Toggle favorite GIFs' })).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('persists favorite GIF section expansion changes', () => {
+    getStoredFavoriteGifIdsMock.mockReturnValue(['favorite-1'])
+
+    render(<GiphyVotingPanel onVoteSubmit={vi.fn()} />)
+    const favoritesToggle = screen.getByRole('button', { name: 'Toggle favorite GIFs' })
+
+    fireEvent.click(favoritesToggle)
+    expect(setStoredFavoriteGifsExpandedMock).toHaveBeenLastCalledWith(false)
+
+    fireEvent.click(favoritesToggle)
+    expect(setStoredFavoriteGifsExpandedMock).toHaveBeenLastCalledWith(true)
   })
 })

--- a/PointerStar/ClientApp/src/components/GiphyVotingPanel.tsx
+++ b/PointerStar/ClientApp/src/components/GiphyVotingPanel.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   Box,
   Button,
+  ButtonBase,
   Collapse,
   CircularProgress,
   IconButton,
@@ -22,7 +23,12 @@ import FavoriteIcon from '@mui/icons-material/Favorite'
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder'
 import SearchIcon from '@mui/icons-material/Search'
 import type { GiphyItem } from '../types/contracts'
-import { getStoredFavoriteGifIds, setStoredFavoriteGifIds } from '../services/cookies'
+import {
+  getStoredFavoriteGifIds,
+  getStoredFavoriteGifsExpanded,
+  setStoredFavoriteGifIds,
+  setStoredFavoriteGifsExpanded,
+} from '../services/cookies'
 import { GIPHY_PAGE_SIZE, searchGiphy } from '../services/giphyApi'
 
 interface GiphyVotingPanelProps {
@@ -60,7 +66,7 @@ export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({
   const [nextOffset, setNextOffset] = useState(0)
   const [hasMoreResults, setHasMoreResults] = useState(false)
   const [favoriteGifIds, setFavoriteGifIds] = useState<string[]>(() => getStoredFavoriteGifIds())
-  const [areFavoritesExpanded, setAreFavoritesExpanded] = useState(true)
+  const [areFavoritesExpanded, setAreFavoritesExpanded] = useState(() => getStoredFavoriteGifsExpanded())
   const requestIdRef = useRef(0)
   const favoriteGifSet = useMemo(() => new Set(favoriteGifIds), [favoriteGifIds])
   const favoriteGifs = useMemo(
@@ -75,6 +81,10 @@ export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({
   useEffect(() => {
     setStoredFavoriteGifIds(favoriteGifIds)
   }, [favoriteGifIds])
+
+  useEffect(() => {
+    setStoredFavoriteGifsExpanded(areFavoritesExpanded)
+  }, [areFavoritesExpanded])
 
   const handleSearch = useCallback(
     async (query: string, offset = 0, append = false) => {
@@ -238,17 +248,29 @@ export const GiphyVotingPanel: React.FC<GiphyVotingPanelProps> = ({
       ) : (
         <>
           <Paper sx={{ marginBottom: 2, padding: 1.5 }} variant="outlined">
-            <Box sx={{ alignItems: 'center', display: 'flex', justifyContent: 'space-between' }}>
+            <ButtonBase
+              aria-expanded={areFavoritesExpanded}
+              aria-label="Toggle favorite GIFs"
+              onClick={() => setAreFavoritesExpanded((expanded) => !expanded)}
+              sx={{
+                alignItems: 'center',
+                borderRadius: 1,
+                display: 'flex',
+                justifyContent: 'space-between',
+                px: 0.5,
+                py: 0.25,
+                textAlign: 'left',
+                width: '100%',
+              }}
+            >
               <Typography variant="subtitle2">Favorite GIFs ({favoriteGifIds.length})</Typography>
-              <Button
-                endIcon={areFavoritesExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-                onClick={() => setAreFavoritesExpanded((expanded) => !expanded)}
-                size="small"
-                variant="text"
-              >
-                {areFavoritesExpanded ? 'Hide' : 'Show'}
-              </Button>
-            </Box>
+              <Box sx={{ alignItems: 'center', display: 'flex', gap: 0.5 }}>
+                <Typography color="text.secondary" variant="body2">
+                  {areFavoritesExpanded ? 'Hide' : 'Show'}
+                </Typography>
+                {areFavoritesExpanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+              </Box>
+            </ButtonBase>
             <Collapse in={areFavoritesExpanded}>
               {favoriteGifs.length > 0 ? (
                 <ImageList cols={giphyColumns} gap={8} sx={{ marginTop: 1 }} variant="masonry">

--- a/PointerStar/ClientApp/src/services/cookies.test.ts
+++ b/PointerStar/ClientApp/src/services/cookies.test.ts
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import {
   acceptCookies,
   getStoredFavoriteGifIds,
+  getStoredFavoriteGifsExpanded,
   getStoredName,
   getStoredRecentGifSearches,
   hasCookieConsent,
   hasUserRespondedToConsent,
   rejectCookies,
   setStoredFavoriteGifIds,
+  setStoredFavoriteGifsExpanded,
   setStoredName,
   setStoredRecentGifSearches,
 } from './cookies'
@@ -98,5 +100,24 @@ describe('cookies', () => {
     setStoredFavoriteGifIds([])
 
     expect(getStoredFavoriteGifIds()).toEqual([])
+  })
+
+  it('defaults favorite GIF section expansion to true when nothing is stored', () => {
+    expect(getStoredFavoriteGifsExpanded()).toBe(true)
+  })
+
+  it('blocks favorite GIF section expansion writes until consent is accepted', () => {
+    setStoredFavoriteGifsExpanded(false)
+
+    expect(getStoredFavoriteGifsExpanded()).toBe(true)
+  })
+
+  it('persists and restores favorite GIF section expansion after consent is accepted', () => {
+    acceptCookies()
+    setStoredFavoriteGifsExpanded(false)
+    expect(getStoredFavoriteGifsExpanded()).toBe(false)
+
+    setStoredFavoriteGifsExpanded(true)
+    expect(getStoredFavoriteGifsExpanded()).toBe(true)
   })
 })

--- a/PointerStar/ClientApp/src/services/cookies.ts
+++ b/PointerStar/ClientApp/src/services/cookies.ts
@@ -1,6 +1,7 @@
 const acceptedValue = 'accepted'
 const consentCookieKey = 'CookieConsent'
 const defaultExpirationDays = 30
+const favoriteGifsExpandedKey = 'FavoriteGifsExpanded'
 const favoriteGifIdsKey = 'FavoriteGifIds'
 const nameKey = 'Name'
 const recentGifSearchesKey = 'RecentGifSearches'
@@ -159,4 +160,17 @@ export function getStoredFavoriteGifIds(): string[] {
 
 export function setStoredFavoriteGifIds(value: string[]) {
   setCookieValue(favoriteGifIdsKey, value.length > 0 ? JSON.stringify(value) : '')
+}
+
+export function getStoredFavoriteGifsExpanded() {
+  const value = getCookieValue(favoriteGifsExpandedKey)
+  if (!value) {
+    return true
+  }
+
+  return value !== 'false'
+}
+
+export function setStoredFavoriteGifsExpanded(value: boolean) {
+  setCookieValue(favoriteGifsExpandedKey, String(value))
 }


### PR DESCRIPTION
Add cookie-based persistence for the expansion state of the favorite GIFs section in the GiphyVotingPanel, ensuring the user's preference is maintained across sessions.
